### PR TITLE
Add simulation log when submitting bitsim orchestration jobs

### DIFF
--- a/mc/autostep.py
+++ b/mc/autostep.py
@@ -73,7 +73,7 @@ def autostep_config(
     # after first iteration, matsim should have created the dir already (for previous step outputs).
     biteration_matsim_config_path.parent.mkdir(parents=True, exist_ok=True)
     config.write(biteration_matsim_config_path)
-    
+
     # summarise the key information from matsim config to a text file
     write_summary_log(config, biteration_matsim_config_path)
 

--- a/mc/autostep.py
+++ b/mc/autostep.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from mc.base import BaseConfig, Param
 from mc.logger import logging
+from mc.summarise import write_summary_log
 
 DEFAULT_MATSIM_CONFIG_NAME = "matsim_config.xml"
 DEFAULT_PLANS_NAME = "output_plans.xml.gz"
@@ -72,6 +73,9 @@ def autostep_config(
     # after first iteration, matsim should have created the dir already (for previous step outputs).
     biteration_matsim_config_path.parent.mkdir(parents=True, exist_ok=True)
     config.write(biteration_matsim_config_path)
+    
+    # summarise the key information from matsim config to a text file
+    write_summary_log(config, biteration_matsim_config_path)
 
     logging.info("Autostep complete")
 

--- a/mc/autostep.py
+++ b/mc/autostep.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from mc.base import BaseConfig, Param
 from mc.logger import logging
-from mc.summarise import write_summary_log
+from mc.summarise import summarise_config
 
 DEFAULT_MATSIM_CONFIG_NAME = "matsim_config.xml"
 DEFAULT_PLANS_NAME = "output_plans.xml.gz"
@@ -75,7 +75,8 @@ def autostep_config(
     config.write(biteration_matsim_config_path)
 
     # summarise the key information from matsim config to a text file
-    write_summary_log(config, biteration_matsim_config_path)
+    text_log_path = biteration_matsim_config_path.parent
+    summarise_config(config, text_log_path)
 
     logging.info("Autostep complete")
 

--- a/mc/summarise.py
+++ b/mc/summarise.py
@@ -44,7 +44,7 @@ def write_text(text, output_path):
     """
     Write the key information into a text file
     """
-    textfile = open(os.path.join(output_path,'simulation_log.txt'), 'w')
+    textfile = open(os.path.join(output_path, 'simulation_log.txt'), 'w')
     for element in text:
         textfile.write(element + "\n")
     textfile.close()

--- a/mc/summarise.py
+++ b/mc/summarise.py
@@ -1,34 +1,43 @@
 import os
 
+
 def write_summary_log(config, output_path):
     """
     Summarise the key information as text log from matsim config when submitting jobs via the Bitsim Orchestration
-    
     """
     message = []
+
     # add paths of the input files
     message.append("{:=^100s}".format("input files"))
     message.append(f"network_path:{config['network']['inputNetworkFile']}")
     message.append(f"plans_path:{config['plans']['inputPlansFile']}")
     message.append(f"schedule_path:{config['transit']['transitScheduleFile']}")
     message.append(f"vehicles_path:{config['transit']['vehiclesFile']}")
+
     # add mobsim setting summary
     message.append("{:=^100s}".format("mobsim setting"))
     message.append(f"mobsim:{config['controler']['mobsim']}")
     message.append(f"Flow_Capacity_Factor:{config[config['controler']['mobsim']]['flowCapacityFactor']}")
     message.append(f"Storage_Capacity_Factor:{config[config['controler']['mobsim']]['storageCapacityFactor']}")
+
     # check mode choice
     message.append("{:=^100s}".format("mode"))
     message.append(f"{config['subtourModeChoice']['modes']}")
+
     # summarise the scoring parameters for each mode
     message.append("{:=^100s}".format("parameters for scoring"))
     for i in config['subtourModeChoice']['modes'].split(','):
         message.append("{:-^100s}".format("mode:" + str(i)))
         score_para = config['planCalcScore']['scoringParameters:default']
-        message.append(f"mode_specific_constant:{score_para['modeParams:' + str(i)]['monetaryDistanceRate']}")
-        message.append(f"marginal_utility_of_distance:{score_para['modeParams:' + str(i)]['marginalUtilityOfDistance_util_m']}") 
-        message.append(f"marginal_utility_of_traveling:{score_para['modeParams:' + str(i)]['marginalUtilityOfTraveling_util_hr']}") 
-        message.append(f"monetary_distance_rate:{score_para['modeParams:' + str(i)]['monetaryDistanceRate']}") 
+        message.append(f"mode_specific_constant:\
+{score_para['modeParams:' + str(i)]['monetaryDistanceRate']}")
+        message.append(f"marginal_utility_of_distance:\
+{score_para['modeParams:' + str(i)]['marginalUtilityOfDistance_util_m']}")
+        message.append(f"marginal_utility_of_traveling:\
+{score_para['modeParams:' + str(i)]['marginalUtilityOfTraveling_util_hr']}")
+        message.append(f"monetary_distance_rate:\
+{score_para['modeParams:' + str(i)]['monetaryDistanceRate']}")
+
     # write the above key information to a text file
     textfile = open(os.path.join(output_path, 'simulation_log.txt'), 'w')
     for element in message:

--- a/mc/summarise.py
+++ b/mc/summarise.py
@@ -1,9 +1,10 @@
 import os
 
 
-def build_summary(config):
+def diretory_log_summary(config):
     """
-    Summarise the key information as text log from matsim config when submitting jobs via the Bitsim Orchestration
+    Summarise the input and out diretories and key information as text log from matsim config
+    When submitting jobs via the Bitsim Orchestration
     """
     message = []
 
@@ -14,29 +15,71 @@ def build_summary(config):
     message.append(f"schedule_path:{config['transit']['transitScheduleFile']}")
     message.append(f"vehicles_path:{config['transit']['vehiclesFile']}")
 
+    # add paths of the output diretory
+    message.append("{:=^100s}".format("output directory"))
+    message.append(f"output_directory:{config['controler']['outputDirectory']}")
+
     # add mobsim setting summary
     message.append("{:=^100s}".format("mobsim setting"))
     message.append(f"mobsim:{config['controler']['mobsim']}")
     message.append(f"Flow_Capacity_Factor:{config[config['controler']['mobsim']]['flowCapacityFactor']}")
     message.append(f"Storage_Capacity_Factor:{config[config['controler']['mobsim']]['storageCapacityFactor']}")
 
+    return message
+
+
+def scoring_summary(config):
+    """
+    Summarise the key scoring parameters
+
+    """
+    message = diretory_log_summary(config)
+
     # check mode choice
     message.append("{:=^100s}".format("mode"))
     message.append(f"{config['subtourModeChoice']['modes']}")
+    dict1 = {}
+    for mode in (config['subtourModeChoice']['modes'].split(',')):
+        dict1[mode] = ["mode_specific_constant:",
+                       "marginal_utility_of_distance:",
+                       "marginal_utility_of_traveling:",
+                       "monetary_distance_rate:"]
+
+    # add subpopulation in the score calcualtion
+    subpopulation_set = set()
+    subpop = 'subpopulation: '
+    for i in config['planCalcScore'].find('subpopulation'):
+        subpopulation_set.add(i.value)
+        subpop = subpop + str(i.value) + ','
 
     # summarise the scoring parameters for each mode
+    performing = "performing:"
+    utility = 'marginalUtilityOfMoney:'
     message.append("{:=^100s}".format("parameters for scoring"))
-    for i in config['subtourModeChoice']['modes'].split(','):
-        message.append("{:-^100s}".format("mode:" + str(i)))
-        score_para = config['planCalcScore']['scoringParameters:default']
-        message.append(f"mode_specific_constant:\
-{score_para['modeParams:' + str(i)]['monetaryDistanceRate']}")
-        message.append(f"marginal_utility_of_distance:\
-{score_para['modeParams:' + str(i)]['marginalUtilityOfDistance_util_m']}")
-        message.append(f"marginal_utility_of_traveling:\
-{score_para['modeParams:' + str(i)]['marginalUtilityOfTraveling_util_hr']}")
-        message.append(f"monetary_distance_rate:\
-{score_para['modeParams:' + str(i)]['monetaryDistanceRate']}")
+    for i in subpopulation_set:
+        score_para = config['planCalcScore']['scoringParameters:' + str(i)]
+        performing += score_para['performing'] + ','
+        utility += score_para['marginalUtilityOfMoney'] + ','
+
+        for idx, mode in enumerate(config['subtourModeChoice']['modes'].split(',')):
+            dict1[mode][0] += str(score_para['modeParams:' + str(mode)]['monetaryDistanceRate'] + ',')
+            dict1[mode][1] += str(score_para['modeParams:' + str(mode)]['marginalUtilityOfDistance_util_m'] + ',')
+            dict1[mode][2] += str(score_para['modeParams:' + str(mode)]['marginalUtilityOfTraveling_util_hr'] + ',')
+            dict1[mode][3] += str(score_para['modeParams:' + str(mode)]['monetaryDistanceRate'] + ',')
+
+    # add scoring parameters for different subpopulation
+    message.append("{:=^100s}".format("subpopulation"))
+    message.append(subpop)
+    message.append("{:=^50s}".format("scoring parameters for subpopulation"))
+    message.append(utility)
+    message.append(performing)
+
+    # append the scoring parameters for each mode to the log
+    for mode in (config['subtourModeChoice']['modes'].split(',')):
+        message.append("{:-^50s}".format("mode:" + str(mode)))
+        for para in dict1[mode]:
+            message.append(para)
+
     return message
 
 
@@ -51,5 +94,5 @@ def write_text(text, output_path):
 
 
 def summarise_config(config, output_path):
-    text = build_summary(config)
+    text = scoring_summary(config)
     write_text(text, output_path)

--- a/mc/summarise.py
+++ b/mc/summarise.py
@@ -1,0 +1,40 @@
+import os
+
+def write_summary_log(config, output_path):
+    """
+    Summarise the key information as text log from matsim config when submitting jobs via the Bitsim Orchestration
+    
+    """
+    message = []
+    
+    #add paths of the input files
+    message.append("{:=^100s}".format("input files"))
+    message.append(f"network_path:{config['network']['inputNetworkFile']}")
+    message.append(f"plans_path:{config['plans']['inputPlansFile']}")
+    message.append(f"schedule_path:{config['transit']['transitScheduleFile']}")
+    message.append(f"vehicles_path:{config['transit']['vehiclesFile']}")
+    
+    #add mobsim setting summary
+    message.append("{:=^100s}".format("mobsim setting"))
+    message.append(f"mobsim:{config['controler']['mobsim']}")
+    message.append(f"Flow_Capacity_Factor:{config[config['controler']['mobsim']]['flowCapacityFactor']}")
+    message.append(f"Storage_Capacity_Factor:{config[config['controler']['mobsim']]['storageCapacityFactor']}")
+    
+    #check mode choice
+    message.append("{:=^100s}".format("mode"))
+    message.append(f"{config['subtourModeChoice']['modes']}")
+
+    #summarise the scoring parameters for each mode 
+    message.append("{:=^100s}".format("parameters for scoring"))
+    for i in config['subtourModeChoice']['modes'].split(','):
+        message.append("{:-^100s}".format("mode:"+ str(i)))
+        message.append(f"mode_specific_constant:{config['planCalcScore']['scoringParameters:default']['modeParams:'+ str(i)]['monetaryDistanceRate']}")
+        message.append(f"marginal_utility_of_distance:{config['planCalcScore']['scoringParameters:default']['modeParams:'+ str(i)]['marginalUtilityOfDistance_util_m']}") 
+        message.append(f"marginal_utility_of_traveling:{config['planCalcScore']['scoringParameters:default']['modeParams:'+ str(i)]['marginalUtilityOfTraveling_util_hr']}") 
+        message.append(f"monetary_distance_rate:{config['planCalcScore']['scoringParameters:default']['modeParams:'+ str(i)]['monetaryDistanceRate']}") 
+    
+    #write the above key information to a text file
+    textfile = open(os.path.join(output_path,'simulation_log.txt'), 'w')
+    for element in message:
+        textfile.write(element + "\n")
+    textfile.close()

--- a/mc/summarise.py
+++ b/mc/summarise.py
@@ -1,7 +1,7 @@
 import os
 
 
-def write_summary_log(config, output_path):
+def build_summary(config):
     """
     Summarise the key information as text log from matsim config when submitting jobs via the Bitsim Orchestration
     """
@@ -37,9 +37,19 @@ def write_summary_log(config, output_path):
 {score_para['modeParams:' + str(i)]['marginalUtilityOfTraveling_util_hr']}")
         message.append(f"monetary_distance_rate:\
 {score_para['modeParams:' + str(i)]['monetaryDistanceRate']}")
+    return message
 
-    # write the above key information to a text file
-    textfile = open(os.path.join(output_path, 'simulation_log.txt'), 'w')
-    for element in message:
+
+def write_text(text, output_path):
+    """
+    Write the key information into a text file
+    """
+    textfile = open(os.path.join(output_path,'simulation_log.txt'), 'w')
+    for element in text:
         textfile.write(element + "\n")
     textfile.close()
+
+
+def summarise_config(config, output_path):
+    text = build_summary(config)
+    write_text(text, output_path)

--- a/mc/summarise.py
+++ b/mc/summarise.py
@@ -7,24 +7,24 @@ def write_summary_log(config, output_path):
     """
     message = []
     
-    #add paths of the input files
+    # add paths of the input files
     message.append("{:=^100s}".format("input files"))
     message.append(f"network_path:{config['network']['inputNetworkFile']}")
     message.append(f"plans_path:{config['plans']['inputPlansFile']}")
     message.append(f"schedule_path:{config['transit']['transitScheduleFile']}")
     message.append(f"vehicles_path:{config['transit']['vehiclesFile']}")
     
-    #add mobsim setting summary
+    # add mobsim setting summary
     message.append("{:=^100s}".format("mobsim setting"))
     message.append(f"mobsim:{config['controler']['mobsim']}")
     message.append(f"Flow_Capacity_Factor:{config[config['controler']['mobsim']]['flowCapacityFactor']}")
     message.append(f"Storage_Capacity_Factor:{config[config['controler']['mobsim']]['storageCapacityFactor']}")
     
-    #check mode choice
+    # check mode choice
     message.append("{:=^100s}".format("mode"))
     message.append(f"{config['subtourModeChoice']['modes']}")
 
-    #summarise the scoring parameters for each mode 
+    # summarise the scoring parameters for each mode 
     message.append("{:=^100s}".format("parameters for scoring"))
     for i in config['subtourModeChoice']['modes'].split(','):
         message.append("{:-^100s}".format("mode:"+ str(i)))
@@ -33,7 +33,7 @@ def write_summary_log(config, output_path):
         message.append(f"marginal_utility_of_traveling:{config['planCalcScore']['scoringParameters:default']['modeParams:'+ str(i)]['marginalUtilityOfTraveling_util_hr']}") 
         message.append(f"monetary_distance_rate:{config['planCalcScore']['scoringParameters:default']['modeParams:'+ str(i)]['monetaryDistanceRate']}") 
     
-    #write the above key information to a text file
+    # write the above key information to a text file
     textfile = open(os.path.join(output_path,'simulation_log.txt'), 'w')
     for element in message:
         textfile.write(element + "\n")

--- a/mc/summarise.py
+++ b/mc/summarise.py
@@ -6,35 +6,31 @@ def write_summary_log(config, output_path):
     
     """
     message = []
-    
     # add paths of the input files
     message.append("{:=^100s}".format("input files"))
     message.append(f"network_path:{config['network']['inputNetworkFile']}")
     message.append(f"plans_path:{config['plans']['inputPlansFile']}")
     message.append(f"schedule_path:{config['transit']['transitScheduleFile']}")
     message.append(f"vehicles_path:{config['transit']['vehiclesFile']}")
-    
     # add mobsim setting summary
     message.append("{:=^100s}".format("mobsim setting"))
     message.append(f"mobsim:{config['controler']['mobsim']}")
     message.append(f"Flow_Capacity_Factor:{config[config['controler']['mobsim']]['flowCapacityFactor']}")
     message.append(f"Storage_Capacity_Factor:{config[config['controler']['mobsim']]['storageCapacityFactor']}")
-    
     # check mode choice
     message.append("{:=^100s}".format("mode"))
     message.append(f"{config['subtourModeChoice']['modes']}")
-
-    # summarise the scoring parameters for each mode 
+    # summarise the scoring parameters for each mode
     message.append("{:=^100s}".format("parameters for scoring"))
     for i in config['subtourModeChoice']['modes'].split(','):
-        message.append("{:-^100s}".format("mode:"+ str(i)))
-        message.append(f"mode_specific_constant:{config['planCalcScore']['scoringParameters:default']['modeParams:'+ str(i)]['monetaryDistanceRate']}")
-        message.append(f"marginal_utility_of_distance:{config['planCalcScore']['scoringParameters:default']['modeParams:'+ str(i)]['marginalUtilityOfDistance_util_m']}") 
-        message.append(f"marginal_utility_of_traveling:{config['planCalcScore']['scoringParameters:default']['modeParams:'+ str(i)]['marginalUtilityOfTraveling_util_hr']}") 
-        message.append(f"monetary_distance_rate:{config['planCalcScore']['scoringParameters:default']['modeParams:'+ str(i)]['monetaryDistanceRate']}") 
-    
+        message.append("{:-^100s}".format("mode:" + str(i)))
+        score_para = config['planCalcScore']['scoringParameters:default']
+        message.append(f"mode_specific_constant:{score_para['modeParams:' + str(i)]['monetaryDistanceRate']}")
+        message.append(f"marginal_utility_of_distance:{score_para['modeParams:' + str(i)]['marginalUtilityOfDistance_util_m']}") 
+        message.append(f"marginal_utility_of_traveling:{score_para['modeParams:' + str(i)]['marginalUtilityOfTraveling_util_hr']}") 
+        message.append(f"monetary_distance_rate:{score_para['modeParams:' + str(i)]['monetaryDistanceRate']}") 
     # write the above key information to a text file
-    textfile = open(os.path.join(output_path,'simulation_log.txt'), 'w')
+    textfile = open(os.path.join(output_path, 'simulation_log.txt'), 'w')
     for element in message:
         textfile.write(element + "\n")
     textfile.close()

--- a/tests/test_data/simulation_log.txt
+++ b/tests/test_data/simulation_log.txt
@@ -3,6 +3,8 @@ network_path:~/test/network.xml
 plans_path:~/test/population.xml.gz
 schedule_path:~/test/schedule-merged.xml
 vehicles_path:~/test/vehicles.xml
+==========================================output directory==========================================
+output_directory:model_out
 ===========================================mobsim setting===========================================
 mobsim:qsim
 Flow_Capacity_Factor:0.01
@@ -10,28 +12,33 @@ Storage_Capacity_Factor:0.01
 ================================================mode================================================
 car,bus,train,walk,bike
 =======================================parameters for scoring=======================================
-----------------------------------------------mode:car----------------------------------------------
-mode_specific_constant:-0.0
-marginal_utility_of_distance:0.0
-marginal_utility_of_traveling:-6.0
-monetary_distance_rate:-0.0
-----------------------------------------------mode:bus----------------------------------------------
-mode_specific_constant:-0.0
-marginal_utility_of_distance:-0.0
-marginal_utility_of_traveling:-12.0
-monetary_distance_rate:-0.0
----------------------------------------------mode:train---------------------------------------------
-mode_specific_constant:-0.0
-marginal_utility_of_distance:-0.0
-marginal_utility_of_traveling:-12.0
-monetary_distance_rate:-0.0
----------------------------------------------mode:walk----------------------------------------------
-mode_specific_constant:0.0
-marginal_utility_of_distance:-0.0
-marginal_utility_of_traveling:-12.0
-monetary_distance_rate:0.0
----------------------------------------------mode:bike----------------------------------------------
-mode_specific_constant:-0.0
-marginal_utility_of_distance:-0.0
-marginal_utility_of_traveling:-12.0
-monetary_distance_rate:-0.0
+===========================================subpopulation============================================
+subpopulation: default,unknown,
+=======scoring parameters for subpopulation=======
+marginalUtilityOfMoney:0.0,0.0,
+performing:6.0,6.0,
+---------------------mode:car---------------------
+mode_specific_constant:-0.0,-0.0,
+marginal_utility_of_distance:0.0,0.0,
+marginal_utility_of_traveling:-6.0,-6.0,
+monetary_distance_rate:-0.0,-0.0,
+---------------------mode:bus---------------------
+mode_specific_constant:-0.0,-0.0,
+marginal_utility_of_distance:-0.0,-0.0,
+marginal_utility_of_traveling:-12.0,-12.0,
+monetary_distance_rate:-0.0,-0.0,
+--------------------mode:train--------------------
+mode_specific_constant:-0.0,-0.0,
+marginal_utility_of_distance:-0.0,-0.0,
+marginal_utility_of_traveling:-12.0,-12.0,
+monetary_distance_rate:-0.0,-0.0,
+--------------------mode:walk---------------------
+mode_specific_constant:0.0,0.0,
+marginal_utility_of_distance:-0.0,-0.0,
+marginal_utility_of_traveling:-12.0,-12.0,
+monetary_distance_rate:0.0,0.0,
+--------------------mode:bike---------------------
+mode_specific_constant:-0.0,-0.0,
+marginal_utility_of_distance:-0.0,-0.0,
+marginal_utility_of_traveling:-12.0,-12.0,
+monetary_distance_rate:-0.0,-0.0,

--- a/tests/test_data/simulation_log.txt
+++ b/tests/test_data/simulation_log.txt
@@ -1,0 +1,37 @@
+============================================input files=============================================
+network_path:~/test/network.xml
+plans_path:~/test/population.xml.gz
+schedule_path:~/test/schedule-merged.xml
+vehicles_path:~/test/vehicles.xml
+===========================================mobsim setting===========================================
+mobsim:qsim
+Flow_Capacity_Factor:0.01
+Storage_Capacity_Factor:0.01
+================================================mode================================================
+car,bus,train,walk,bike
+=======================================parameters for scoring=======================================
+----------------------------------------------mode:car----------------------------------------------
+mode_specific_constant:-0.0
+marginal_utility_of_distance:0.0
+marginal_utility_of_traveling:-6.0
+monetary_distance_rate:-0.0
+----------------------------------------------mode:bus----------------------------------------------
+mode_specific_constant:-0.0
+marginal_utility_of_distance:-0.0
+marginal_utility_of_traveling:-12.0
+monetary_distance_rate:-0.0
+---------------------------------------------mode:train---------------------------------------------
+mode_specific_constant:-0.0
+marginal_utility_of_distance:-0.0
+marginal_utility_of_traveling:-12.0
+monetary_distance_rate:-0.0
+---------------------------------------------mode:walk----------------------------------------------
+mode_specific_constant:0.0
+marginal_utility_of_distance:-0.0
+marginal_utility_of_traveling:-12.0
+monetary_distance_rate:0.0
+---------------------------------------------mode:bike----------------------------------------------
+mode_specific_constant:-0.0
+marginal_utility_of_distance:-0.0
+marginal_utility_of_traveling:-12.0
+monetary_distance_rate:-0.0


### PR DESCRIPTION
In order to compare the key parameters sets between various simulations easily, it would be useful to have the key information summary of the matsim config as a log file when we submit jobs via bitsim orchestration. 

The first step is to create the log file along with every biteration. The summary log will be written in the text file including input files paths, information about mobsim and key scoring parameters for different mode from matsim config. These parameters are usually to be changed frequently when we run experimental simulations. 

The text log file has the consistent format and is easy to be merged. Next step we are planning to create only one summary log for different simulation jobs via bitsim orchestration. 