### PR TITLE
Update github build to use main rather than master as the name of the…

### DIFF
--- a/.github/workflows/build_pipeline.yml
+++ b/.github/workflows/build_pipeline.yml
@@ -44,10 +44,10 @@ jobs:
         echo $repo_slug
         echo $GITHUB_SHA
         echo $GITHUB_SHA > release
-        if test "$GITHUB_REF" = "refs/heads/master"; then
-          echo "Branch is master - no need to make a release name..."
+        if test "$GITHUB_REF" = "refs/heads/main"; then
+          echo "Branch is main - no need to make a release name..."
         else
-          echo "Making a release name for non-master branch..."
+          echo "Making a release name for non-main branch..."
           branch=`echo $GITHUB_REF | awk -F '/' '{print $3}'`
           release_name=`echo $GITHUB_ACTOR-$branch`
           echo "Release name: $release_name"


### PR DESCRIPTION
… main branch

We moved from `master` to `main` a while back, but did not update the github build to reflect this change. The downstream effect of this mismatch was that MC Docker images in ECR were never tagged as `latest`, because the GitHub build was creating a `release_name` file in the repo bundle for any branch **not** called `master`, and the CodeBuild job only tags an image as `latest` when there is no such `relase_name` file.

You can see the modified logic in the build of this branch [from this line onwards](https://github.com/arup-group/mc/runs/4920615061?check_suite_focus=true#step:10:29).

Once we're merged this PR we will need to confirm that the `latest` image tag is reassigned by the subsequent CodeBuild job.

Perhaps we should tweak this mechanism such that it is possible to have both a `latest` tag **and** a release name tag, @rorysedgwick ? That seems like a thing we will need.