### PR TITLE
Fix the inconsistency bug for mode in subpopulation

### DIFF
--- a/mc/summarise.py
+++ b/mc/summarise.py
@@ -2,7 +2,7 @@ import os
 from datetime import date
 
 
-def diretory_log_summary(config):
+def directory_log_summary(config):
     """
     Summarise the input and out diretories and key information as text log from matsim config
     When submitting jobs via the Bitsim Orchestration
@@ -36,18 +36,17 @@ def scoring_summary(config):
     Summarise the key scoring parameters
 
     """
-    message = diretory_log_summary(config)
+    message = directory_log_summary(config)
 
     # check mode choice
     message.append("{:=^100s}".format("mode"))
     message.append(f"{config['subtourModeChoice']['modes']}")
-    dict1 = {}
+    parm = {}
     for mode in (config['subtourModeChoice']['modes'].split(',')):
-        dict1[mode] = ["mode_specific_constant:",
-                       "marginal_utility_of_distance:",
-                       "marginal_utility_of_traveling:",
-                       "monetary_distance_rate:"]
-
+        parm[mode] = ["mode_specific_constant:",
+                      "marginal_utility_of_distance:",
+                      "marginal_utility_of_traveling:",
+                      "monetary_distance_rate:"]
     # add subpopulation in the score calcualtion
     subpopulation_set = {}
     subpop = 'subpopulation: '
@@ -62,21 +61,21 @@ def scoring_summary(config):
     utility = 'marginalUtilityOfMoney:'
     message.append("{:=^100s}".format("parameters for scoring"))
     for i in subpopulation_set:
-        score_para = config['planCalcScore']['scoringParameters:' + str(i)]
-        performing += score_para['performing'] + ','
-        utility += score_para['marginalUtilityOfMoney'] + ','
+        score_parm = config['planCalcScore']['scoringParameters:' + str(i)]
+        performing += score_parm['performing'] + ','
+        utility += score_parm['marginalUtilityOfMoney'] + ','
 
         for idx, mode in enumerate(config['subtourModeChoice']['modes'].split(',')):
             if mode not in subpopulation_set[str(i)]:
-                dict1[mode][0] += 'NA'
-                dict1[mode][1] += 'NA'
-                dict1[mode][2] += 'NA'
-                dict1[mode][3] += 'NA'
+                parm[mode][0] += 'NA'
+                parm[mode][1] += 'NA'
+                parm[mode][2] += 'NA'
+                parm[mode][3] += 'NA'
             else:
-                dict1[mode][0] += str(score_para['modeParams:' + str(mode)]['monetaryDistanceRate'] + ',')
-                dict1[mode][1] += str(score_para['modeParams:' + str(mode)]['marginalUtilityOfDistance_util_m'] + ',')
-                dict1[mode][2] += str(score_para['modeParams:' + str(mode)]['marginalUtilityOfTraveling_util_hr'] + ',')
-                dict1[mode][3] += str(score_para['modeParams:' + str(mode)]['monetaryDistanceRate'] + ',')
+                parm[mode][0] += str(score_parm['modeParams:' + str(mode)]['monetaryDistanceRate'] + ',')
+                parm[mode][1] += str(score_parm['modeParams:' + str(mode)]['marginalUtilityOfDistance_util_m'] + ',')
+                parm[mode][2] += str(score_parm['modeParams:' + str(mode)]['marginalUtilityOfTraveling_util_hr'] + ',')
+                parm[mode][3] += str(score_parm['modeParams:' + str(mode)]['monetaryDistanceRate'] + ',')
 
     # add scoring parameters for different subpopulation
     message.append("{:=^100s}".format("subpopulation"))
@@ -88,7 +87,7 @@ def scoring_summary(config):
     # append the scoring parameters for each mode to the log
     for mode in (config['subtourModeChoice']['modes'].split(',')):
         message.append("{:-^50s}".format("mode:" + str(mode)))
-        for para in dict1[mode]:
+        for para in parm[mode]:
             message.append(para)
 
     return message

--- a/tests/test_data/simulation_log.txt
+++ b/tests/test_data/simulation_log.txt
@@ -1,10 +1,9 @@
+Date:2022-02-01
 ============================================input files=============================================
 network_path:~/test/network.xml
 plans_path:~/test/population.xml.gz
 schedule_path:~/test/schedule-merged.xml
 vehicles_path:~/test/vehicles.xml
-==========================================output directory==========================================
-output_directory:model_out
 ===========================================mobsim setting===========================================
 mobsim:qsim
 Flow_Capacity_Factor:0.01
@@ -18,17 +17,17 @@ subpopulation: default,unknown,
 marginalUtilityOfMoney:0.0,0.0,
 performing:6.0,6.0,
 ---------------------mode:car---------------------
-mode_specific_constant:-0.0,-0.0,
+mode_specific_constant:0.0,0.0,
 marginal_utility_of_distance:0.0,0.0,
 marginal_utility_of_traveling:-6.0,-6.0,
 monetary_distance_rate:-0.0,-0.0,
 ---------------------mode:bus---------------------
-mode_specific_constant:-0.0,-0.0,
+mode_specific_constant:0.0,0.0,
 marginal_utility_of_distance:-0.0,-0.0,
 marginal_utility_of_traveling:-12.0,-12.0,
 monetary_distance_rate:-0.0,-0.0,
 --------------------mode:train--------------------
-mode_specific_constant:-0.0,-0.0,
+mode_specific_constant:0.0,0.0,
 marginal_utility_of_distance:-0.0,-0.0,
 marginal_utility_of_traveling:-12.0,-12.0,
 monetary_distance_rate:-0.0,-0.0,
@@ -38,7 +37,7 @@ marginal_utility_of_distance:-0.0,-0.0,
 marginal_utility_of_traveling:-12.0,-12.0,
 monetary_distance_rate:0.0,0.0,
 --------------------mode:bike---------------------
-mode_specific_constant:-0.0,-0.0,
+mode_specific_constant:0.0,0.0,
 marginal_utility_of_distance:-0.0,-0.0,
 marginal_utility_of_traveling:-12.0,-12.0,
 monetary_distance_rate:-0.0,-0.0,

--- a/tests/test_data/simulation_log_nz.txt
+++ b/tests/test_data/simulation_log_nz.txt
@@ -1,0 +1,53 @@
+Date:2022-02-01
+============================================input files=============================================
+network_path:/efs/executions/sixteen-skylark-winner-sweet/new_lane_defaults/network.xml
+plans_path:/efs/inputs/population/v2_20210629/combined/population.xml
+schedule_path:/efs/executions/sixteen-skylark-winner-sweet/genet_output/updated_vehicle_network_20211103/schedule.xml
+vehicles_path:/efs/executions/sixteen-skylark-winner-sweet/genet_output/updated_vehicle_network_20211103/vehicles_1perc.xml
+===========================================mobsim setting===========================================
+mobsim:hermes
+Flow_Capacity_Factor:0.01
+Storage_Capacity_Factor:0.05
+================================================mode================================================
+bus,bike,walk,rail,car,ferry,cablecar
+=======================================parameters for scoring=======================================
+===========================================subpopulation============================================
+subpopulation: default,hhs_carAvailyes,hhs_carAvailnever,hgv,
+=======scoring parameters for subpopulation=======
+marginalUtilityOfMoney:10,10,10,10,
+performing:100,100,100,100,
+---------------------mode:bus---------------------
+mode_specific_constant:-1,-1,-1,NA
+marginal_utility_of_distance:0.0,0.0,0.0,NA
+marginal_utility_of_traveling:-2,-2,-2,NA
+monetary_distance_rate:-0.00036832,-0.00036832,-0.00036832,NA
+--------------------mode:bike---------------------
+mode_specific_constant:-20,-20,-20,NA
+marginal_utility_of_distance:-0.1,-0.1,-0.1,NA
+marginal_utility_of_traveling:0,0,0,NA
+monetary_distance_rate:-0.0,-0.0,-0.0,NA
+--------------------mode:walk---------------------
+mode_specific_constant:-0,-0,-0,NA
+marginal_utility_of_distance:-0.01,-0.01,-0.01,NA
+marginal_utility_of_traveling:0,0,0,NA
+monetary_distance_rate:0.0,0.0,0.0,NA
+--------------------mode:rail---------------------
+mode_specific_constant:-1,-1,-1,NA
+marginal_utility_of_distance:0.0,0.0,0.0,NA
+marginal_utility_of_traveling:-1,-1,-1,NA
+monetary_distance_rate:-0.00011177,-0.00011177,-0.00011177,NA
+---------------------mode:car---------------------
+mode_specific_constant:-20,-20,-20,-20,
+marginal_utility_of_distance:0.0,0.0,0.0,-0.0,
+marginal_utility_of_traveling:-0.0,-0.0,-0.0,-0.0,
+monetary_distance_rate:-0.0001,-0.0001,-0.0001,-0.0001,
+--------------------mode:ferry--------------------
+mode_specific_constant:-1,-1,-1,NA
+marginal_utility_of_distance:0.0,0.0,0.0,NA
+marginal_utility_of_traveling:-2,-2,-2,NA
+monetary_distance_rate:-0.00036832,-0.00036832,-0.00036832,NA
+------------------mode:cablecar-------------------
+mode_specific_constant:-1,-1,-1,NA
+marginal_utility_of_distance:0.0,0.0,0.0,NA
+marginal_utility_of_traveling:-2,-2,-2,NA
+monetary_distance_rate:-0.00036832,-0.00036832,-0.00036832,NA

--- a/tests/test_data/test_matsim_config_nz.xml
+++ b/tests/test_data/test_matsim_config_nz.xml
@@ -1,0 +1,845 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
+<config>
+   <module name="global">
+      <param name="randomSeed" value="4711" />
+      <param name="coordinateSystem" value="EPSG:2193" />
+      <param name="numberOfThreads" value="32" />
+   </module>
+   <module name="network">
+	   <param name="inputNetworkFile" value="/efs/executions/sixteen-skylark-winner-sweet/new_lane_defaults/network.xml" />  
+   </module>
+   <module name="plans">
+      <param name="inputPlansFile" value="/efs/inputs/population/v2_20210629/combined/population.xml"/> 
+   </module>
+   <module name="transit">
+      <param name="useTransit" value="true" />
+      <param name="transitScheduleFile" value="/efs/executions/sixteen-skylark-winner-sweet/genet_output/updated_vehicle_network_20211103/schedule.xml" /> 
+      <param name="vehiclesFile" value="/efs/executions/sixteen-skylark-winner-sweet/genet_output/updated_vehicle_network_20211103/vehicles_1perc.xml" /> 
+      <param name="transitModes" value="bus,rail,ferry,cablecar" />
+   </module>
+   <module name="swissRailRaptor">
+      <param name="useModeMappingForPassengers" value="true" />
+      <parameterset type="intermodalAccessEgress">
+         <param name="mode" value="walk" />
+         <param name="maxRadius" value="10000" />
+      </parameterset>
+      <parameterset type="modeMapping">
+         <param name="routeMode" value="bus" />
+         <param name="passengerMode" value="bus" />
+      </parameterset>
+      <parameterset type="modeMapping">
+         <param name="routeMode" value="rail" />
+         <param name="passengerMode" value="rail" />
+      </parameterset>
+      <parameterset type="modeMapping">
+         <param name="routeMode" value="ferry" />
+         <param name="passengerMode" value="ferry" />
+      </parameterset>
+      <parameterset type="modeMapping">
+         <param name="routeMode" value="cablecar" />
+         <param name="passengerMode" value="cablecar" />
+      </parameterset>
+      <parameterset type="modeMapping">
+         <param name="routeMode" value ="aircraft" />
+         <param name="passengerMode" value="aircraft" />
+      </parameterset>
+   </module>
+   <module name="transitRouter">
+      <!-- additional time the router 
+		allocates when a line switch happens, Can be interpreted as a 'savity' time that agents need 
+		to savely transfer from one line to another -->
+      <param name="additionalTransferTime" value="1.0" />
+      <!-- step size to increase searchRadius if no stops are found -->
+      <param name="extensionRadius" value="2000.0" />
+      <!-- maximum beeline distance between stops that 
+		agents could transfer to by walking -->
+      <param name="maxBeelineWalkConnectionDistance" value="500.0" />
+      <!-- the radius in which stop locations are searched, given a start or 
+		target coordinate -->
+      <param name="searchRadius" value="2000.0" />
+   </module>
+   <module name="TimeAllocationMutator">
+    <!-- Test 1 - reduce time mutation globally         -->
+      <param name="mutationRange" value="50.0" />
+   </module>
+   <module name="controler">
+      <param name="createGraphs" value="true" />
+      <param name="outputDirectory"  value="/efs/simulation-runs/calibration-tests/outputRoadPricingBusUnDeterm/" /> 
+      <param name="firstIteration" value="0" />
+      <param name="lastIteration" value="200" />
+      <param name="eventsFileFormat" value="xml" />
+      <param name="writeEventsInterval" value="10" />
+      <param name="writePlansInterval" value="10" />
+    <!-- test using hermes. Defined below in "Hermes"         -->
+      <param name="mobsim" value="hermes" />
+      <param name="snapshotFormat" value="" />
+      <param name="overwriteFiles" value="deleteDirectoryIfExists" />
+<!-- 		<param name="routingAlgorithmType" value="SpeedyALT" /> -->
+   </module>
+   <module name="subtourModeChoice">
+      <!-- "car,pt,walk,bike" -->
+      <param name="chainBasedModes" value="car,bike" />
+      <param name="modes" value="bus,bike,walk,rail,car,ferry,cablecar" />
+   </module>
+   <module name="parallelEventHandling">
+      <param name="estimatedNumberOfEvents" value="null" />
+      <param name="numberOfThreads" value="32" />
+      <param name="oneThreadPerHandler" value="true" />
+   </module>
+        
+   <module name="hermes" >
+       
+       <param name="endTime" value="32:00:00" />
+       <param name="flowCapacityFactor" value="0.01" />
+       <param name="mainMode" value="car" />
+       <param name="storageCapacityFactor" value="0.05" />
+<!--        <!– time in seconds. Time after which the frontmost vehicle on a link is called `stuck' if it does not move. Set to Integer.MAX_VALUE to disable this behavior –> -->
+       <param name="stuckTime" value="30" />
+<!--        <!– treats PT as deterministic. PT vehicles will run with a steady speed according to their timetable. –> -->
+       <param name="useDeterministicPt" value="false" />
+    </module>
+    
+    <module name="SBBPt" >
+        <param name="deterministicServiceModes" value="rail, ferry, cablecar" />
+        <param name="createLinkEventsInterval" value="10" />
+    </module>
+
+   <module name="planCalcScore">
+      <param name="BrainExpBeta" value="1.0" />
+      <param name="writeExperiencedPlans" value="true" />
+
+      <!-- Subpopulations: {'default', 'hhs_carAvailnever', 'hhs_carAvailyes', 'hgv'} -->
+      <!-- FYI, matsim requires a default subpop 
+		-->
+      <!-- presently, the params for default, hhs_carAvailyes hhs_carAvailnever are the same excepct that hhs_carAvailnever has car at 10x cost (taxi'esque) -->
+      <!-- 
+		Modes: {'bus', 'bike', 'walk', 'rail', 'car', 'ferry'} -->
+      <!-- Activities: {'shop', 'home', 
+		'recreation', 'education', 'other', 'work','escort'} -->
+             
+      <parameterset type="scoringParameters">
+         <param name="earlyDeparture" value="-0.0" />
+        <!-- test 2 - add late cost  -->
+         <param name="lateArrival" value="-50" />
+         <param name="marginalUtilityOfMoney" value="10" />
+         <param name="performing" value="100" />
+         <param name="subpopulation" value="default" />
+         <param name="utilityOfLineSwitch" value="-5" />
+         <param name="waiting" value="-0.0" />
+         <param name="waitingPt" value="0" />
+         <parameterset type="activityParams">
+            <param name="activityType" value="home" />
+            <param name="openingTime" value="undefined" />
+            <param name="closingTime" value="undefined" />
+            <param name="earliestEndTime" value="undefined" />
+            <param name="latestStartTime" value="undefined" />
+            <param name="minimalDuration" value="1:00:00" />
+            <param name="typicalDuration" value="8:00:00" />
+            <param name="priority" value="1.0" />
+            <param name="scoringThisActivityAtAll" value="true" />
+            <param name="typicalDurationScoreComputation" value="relative" />
+         </parameterset>
+         <parameterset type="activityParams">
+            <param name="activityType" value="work" />
+            <param name="openingTime" value="7:00:00" />
+            <param name="closingTime" value="19:30:00" />
+            <param name="earliestEndTime" value="05:30:00" />
+            <param name="latestStartTime" value="21:00:00" />
+            <param name="minimalDuration" value="6:00:00" />
+            <param name="typicalDuration" value="8:30:00" />
+            <param name="priority" value="1.0" />
+            <param name="scoringThisActivityAtAll" value="true" />
+            <param name="typicalDurationScoreComputation" value="relative" />
+         </parameterset>
+         <parameterset type="activityParams">
+            <param name="activityType" value="visit"/>
+            <param name="openingTime" value="08:00:00"/>
+            <param name="closingTime" value="23:59:00"/>
+            <param name="earliestEndTime" value="undefined"/>
+            <param name="latestStartTime" value="undefined"/>
+            <param name="minimalDuration" value="0:30:00"/>
+            <param name="typicalDuration" value="2:00:00"/>
+            <param name="priority" value="1.0"/>
+            <param name="scoringThisActivityAtAll" value="true"/>
+            <param name="typicalDurationScoreComputation" value="relative"/>
+         </parameterset>
+         <parameterset type="activityParams">
+            <param name="activityType" value="shop" />
+            <param name="openingTime" value="08:30:00" />
+            <param name="closingTime" value="17:30:00" />
+            <param name="earliestEndTime" value="undefined" />
+            <param name="latestStartTime" value="undefined" />
+            <param name="minimalDuration" value="0:10:00" />
+            <param name="typicalDuration" value="0:30:00" />
+            <param name="priority" value="1.0" />
+            <param name="scoringThisActivityAtAll" value="true" />
+            <param name="typicalDurationScoreComputation" value="relative" />
+         </parameterset>
+         <!-- borrowed from visit -->
+         <parameterset type="activityParams">
+            <param name="activityType" value="left_country"/>
+            <param name="openingTime" value="08:00:00"/>
+            <param name="closingTime" value="23:59:00"/>
+            <param name="earliestEndTime" value="undefined"/>
+            <param name="latestStartTime" value="undefined"/>
+            <param name="minimalDuration" value="0:30:00"/>
+            <param name="typicalDuration" value="2:00:00"/>
+            <param name="priority" value="1.0"/>
+            <param name="scoringThisActivityAtAll" value="true"/>
+            <param name="typicalDurationScoreComputation" value="relative"/>
+         </parameterset>
+         <parameterset type="activityParams">
+            <param name="activityType" value="education" />
+            <param name="openingTime" value="08:30:00" />
+            <param name="closingTime" value="17:00:00" />
+            <param name="earliestEndTime" value="undefined" />
+            <param name="latestStartTime" value="undefined" />
+            <param name="minimalDuration" value="6:00:00" />
+            <param name="typicalDuration" value="6:00:00" />
+            <param name="priority" value="1.0" />
+            <param name="scoringThisActivityAtAll" value="true" />
+            <param name="typicalDurationScoreComputation" value="relative" />
+         </parameterset>
+         <parameterset type="activityParams">
+            <param name="activityType" value="recreation" />
+            <param name="openingTime" value="06:00:00" />
+            <param name="closingTime" value="23:00:00" />
+            <param name="earliestEndTime" value="undefined" />
+            <param name="latestStartTime" value="undefined" />
+            <param name="minimalDuration" value="0:30:00" />
+            <param name="typicalDuration" value="2:00:00" />
+            <param name="priority" value="1.0" />
+            <param name="scoringThisActivityAtAll" value="true" />
+            <param name="typicalDurationScoreComputation" value="relative" />
+         </parameterset>
+         <parameterset type="activityParams">
+            <param name="activityType" value="escort" />
+            <param name="openingTime" value="08:30:00" />
+            <param name="closingTime" value="17:30:00" />
+            <param name="earliestEndTime" value="undefined" />
+            <param name="latestStartTime" value="undefined" />
+            <param name="minimalDuration" value="0:05:00" />
+            <param name="typicalDuration" value="0:15:00" />
+            <param name="priority" value="1.0" />
+            <param name="scoringThisActivityAtAll" value="true" />
+            <param name="typicalDurationScoreComputation" value="relative" />
+         </parameterset>
+         <parameterset type="activityParams">
+            <param name="activityType" value="other" />
+            <param name="openingTime" value="07:00:00" />
+            <param name="closingTime" value="23:00:00" />
+            <param name="earliestEndTime" value="undefined" />
+            <param name="latestStartTime" value="undefined" />
+            <param name="minimalDuration" value="0:10:00" />
+            <param name="typicalDuration" value="0:30:00" />
+            <param name="priority" value="1.0" />
+            <param name="scoringThisActivityAtAll" value="true" />
+            <param name="typicalDurationScoreComputation" value="relative" />
+         </parameterset>
+         <parameterset type="modeParams">
+            <param name="constant" value="-20" />
+            <param name="marginalUtilityOfDistance_util_m" value="0.0" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="-0.0" />
+            <param name="mode" value="car" />
+            <param name="monetaryDistanceRate" value="-0.0001" />
+         </parameterset>
+         <parameterset type="modeParams">
+            <param name="constant" value="-20" />
+            <param name="dailyMonetaryConstant" value="0" />
+            <param name="dailyUtilityConstant" value="0.0" />
+            <param name="marginalUtilityOfDistance_util_m" value="-0.1" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="0" />
+            <param name="mode" value="bike" />
+            <param name="monetaryDistanceRate" value="-0.0" />
+         </parameterset>
+         <parameterset type="modeParams">
+            <param name="constant" value="-0" />
+            <param name="marginalUtilityOfDistance_util_m" value="-0.01" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="0" />
+            <param name="mode" value="walk" />
+            <param name="monetaryDistanceRate" value="0.0" />
+         </parameterset>
+         <parameterset type="modeParams">
+            <param name="mode" value="pt" />
+            <param name="constant" value="-1000.0" />
+            <param name="marginalUtilityOfDistance_util_m" value="0.0" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="-1" />
+            <param name="monetaryDistanceRate" value="-0.000" />
+         </parameterset>
+         <parameterset type="modeParams">
+            <param name="mode" value="bus" />
+            <param name="constant" value="-1" />
+            <param name="marginalUtilityOfDistance_util_m" value="0.0" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="-2" />
+            <param name="monetaryDistanceRate" value="-0.00036832" />
+         </parameterset>
+         <parameterset type="modeParams">
+            <param name="mode" value="rail" />
+            <param name="constant" value="-1" />
+            <param name="marginalUtilityOfDistance_util_m" value="0.0" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="-1" />
+            <param name="monetaryDistanceRate" value="-0.00011177" />
+         </parameterset>
+         <!-- I copied same attributes as bus -->
+         <parameterset type="modeParams">
+            <param name="mode" value="ferry" />
+            <param name="constant" value="-1" />
+            <param name="marginalUtilityOfDistance_util_m" value="0.0" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="-2" />
+            <param name="monetaryDistanceRate" value="-0.00036832" />
+         </parameterset>
+         <!-- I copied same attributes as bus -->
+         <parameterset type="modeParams">
+            <param name="mode" value="cablecar" />
+            <param name="constant" value="-1" />
+            <param name="marginalUtilityOfDistance_util_m" value="0.0" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="-2" />
+            <param name="monetaryDistanceRate" value="-0.00036832" />
+         </parameterset>
+        <!-- Made it expensive -->
+         <parameterset type="modeParams">
+            <param name="mode" value="aircraft" />
+            <param name="constant" value="-1" />
+            <param name="marginalUtilityOfDistance_util_m" value="0.0" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="-200" />
+            <param name="monetaryDistanceRate" value="-0.00036832" />
+         </parameterset>
+      </parameterset>
+      <parameterset type="scoringParameters">
+         <param name="earlyDeparture" value="-0.0" />
+         <param name="lateArrival" value="-50" />
+         <param name="marginalUtilityOfMoney" value="10" />
+         <param name="performing" value="100" />
+         <param name="subpopulation" value="hhs_carAvailyes" />
+         <param name="utilityOfLineSwitch" value="-5" />
+         <param name="waiting" value="-0.0" />
+         <param name="waitingPt" value="0" />
+         <parameterset type="activityParams">
+            <param name="activityType" value="home" />
+            <param name="openingTime" value="undefined" />
+            <param name="closingTime" value="undefined" />
+            <param name="earliestEndTime" value="undefined" />
+            <param name="latestStartTime" value="undefined" />
+            <param name="minimalDuration" value="1:00:00" />
+            <param name="typicalDuration" value="8:00:00" />
+            <param name="priority" value="1.0" />
+            <param name="scoringThisActivityAtAll" value="true" />
+            <param name="typicalDurationScoreComputation" value="relative" />
+         </parameterset>
+         <parameterset type="activityParams">
+            <param name="activityType" value="work" />
+            <param name="openingTime" value="7:00:00" />
+            <param name="closingTime" value="19:30:00" />
+            <param name="earliestEndTime" value="undefined" />
+            <param name="latestStartTime" value="undefined" />
+            <param name="minimalDuration" value="6:00:00" />
+            <param name="typicalDuration" value="8:30:00" />
+            <param name="priority" value="1.0" />
+            <param name="scoringThisActivityAtAll" value="true" />
+            <param name="typicalDurationScoreComputation" value="relative" />
+         </parameterset>
+         <parameterset type="activityParams">
+            <param name="activityType" value="shop" />
+            <param name="openingTime" value="08:30:00" />
+            <param name="closingTime" value="17:30:00" />
+            <param name="earliestEndTime" value="undefined" />
+            <param name="latestStartTime" value="undefined" />
+            <param name="minimalDuration" value="0:10:00" />
+            <param name="typicalDuration" value="0:30:00" />
+            <param name="priority" value="1.0" />
+            <param name="scoringThisActivityAtAll" value="true" />
+            <param name="typicalDurationScoreComputation" value="relative" />
+         </parameterset>
+         <parameterset type="activityParams">
+            <param name="activityType" value="visit"/>
+            <param name="openingTime" value="08:00:00"/>
+            <param name="closingTime" value="23:59:00"/>
+            <param name="earliestEndTime" value="undefined"/>
+            <param name="latestStartTime" value="undefined"/>
+            <param name="minimalDuration" value="0:30:00"/>
+            <param name="typicalDuration" value="2:00:00"/>
+            <param name="priority" value="1.0"/>
+            <param name="scoringThisActivityAtAll" value="true"/>
+            <param name="typicalDurationScoreComputation" value="relative"/>
+         </parameterset>
+         <!-- borrowed from visit -->
+         <parameterset type="activityParams">
+            <param name="activityType" value="left_country"/>
+            <param name="openingTime" value="08:00:00"/>
+            <param name="closingTime" value="23:59:00"/>
+            <param name="earliestEndTime" value="undefined"/>
+            <param name="latestStartTime" value="undefined"/>
+            <param name="minimalDuration" value="0:30:00"/>
+            <param name="typicalDuration" value="2:00:00"/>
+            <param name="priority" value="1.0"/>
+            <param name="scoringThisActivityAtAll" value="true"/>
+            <param name="typicalDurationScoreComputation" value="relative"/>
+         </parameterset>
+         <parameterset type="activityParams">
+            <param name="activityType" value="education" />
+            <param name="openingTime" value="08:30:00" />
+            <param name="closingTime" value="17:00:00" />
+            <param name="earliestEndTime" value="undefined" />
+            <param name="latestStartTime" value="undefined" />
+            <param name="minimalDuration" value="6:00:00" />
+            <param name="typicalDuration" value="6:00:00" />
+            <param name="priority" value="1.0" />
+            <param name="scoringThisActivityAtAll" value="true" />
+            <param name="typicalDurationScoreComputation" value="relative" />
+         </parameterset>
+         <parameterset type="activityParams">
+            <param name="activityType" value="recreation" />
+            <param name="openingTime" value="06:00:00" />
+            <param name="closingTime" value="23:00:00" />
+            <param name="earliestEndTime" value="undefined" />
+            <param name="latestStartTime" value="undefined" />
+            <param name="minimalDuration" value="0:30:00" />
+            <param name="typicalDuration" value="2:00:00" />
+            <param name="priority" value="1.0" />
+            <param name="scoringThisActivityAtAll" value="true" />
+            <param name="typicalDurationScoreComputation" value="relative" />
+         </parameterset>
+         <parameterset type="activityParams">
+            <param name="activityType" value="escort" />
+            <param name="openingTime" value="08:30:00" />
+            <param name="closingTime" value="17:30:00" />
+            <param name="earliestEndTime" value="undefined" />
+            <param name="latestStartTime" value="undefined" />
+            <param name="minimalDuration" value="0:05:00" />
+            <param name="typicalDuration" value="0:15:00" />
+            <param name="priority" value="1.0" />
+            <param name="scoringThisActivityAtAll" value="true" />
+            <param name="typicalDurationScoreComputation" value="relative" />
+         </parameterset>
+         <parameterset type="activityParams">
+            <param name="activityType" value="other" />
+            <param name="openingTime" value="07:00:00" />
+            <param name="closingTime" value="23:00:00" />
+            <param name="earliestEndTime" value="undefined" />
+            <param name="latestStartTime" value="undefined" />
+            <param name="minimalDuration" value="0:10:00" />
+            <param name="typicalDuration" value="0:30:00" />
+            <param name="priority" value="1.0" />
+            <param name="scoringThisActivityAtAll" value="true" />
+            <param name="typicalDurationScoreComputation" value="relative" />
+         </parameterset>
+         <parameterset type="modeParams">
+            <param name="constant" value="-20" />
+            <param name="marginalUtilityOfDistance_util_m" value="0.0" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="-0.0" />
+            <param name="mode" value="car" />
+            <param name="monetaryDistanceRate" value="-0.0001" />
+         </parameterset>
+         <parameterset type="modeParams">
+            <param name="constant" value="-20" />
+            <param name="dailyMonetaryConstant" value="0" />
+            <param name="dailyUtilityConstant" value="0.0" />
+            <param name="marginalUtilityOfDistance_util_m" value="-0.1" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="0" />
+            <param name="mode" value="bike" />
+            <param name="monetaryDistanceRate" value="-0.0" />
+         </parameterset>
+         <parameterset type="modeParams">
+            <param name="constant" value="-0" />
+            <param name="marginalUtilityOfDistance_util_m" value="-0.01" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="0" />
+            <param name="mode" value="walk" />
+            <param name="monetaryDistanceRate" value="0.0" />
+         </parameterset>
+         <parameterset type="modeParams">
+            <param name="mode" value="pt" />
+            <param name="constant" value="-1000.0" />
+            <param name="marginalUtilityOfDistance_util_m" value="0.0" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="-1" />
+            <param name="monetaryDistanceRate" value="-0.000" />
+         </parameterset>
+         <parameterset type="modeParams">
+            <param name="mode" value="bus" />
+            <param name="constant" value="-1" />
+            <param name="marginalUtilityOfDistance_util_m" value="0.0" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="-2" />
+            <param name="monetaryDistanceRate" value="-0.00036832" />
+         </parameterset>
+         <parameterset type="modeParams">
+            <param name="mode" value="rail" />
+            <param name="constant" value="-1" />
+            <param name="marginalUtilityOfDistance_util_m" value="0.0" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="-1" />
+            <param name="monetaryDistanceRate" value="-0.00011177" />
+         </parameterset>
+         <!-- presently same attributes as bus -->
+         <parameterset type="modeParams">
+            <param name="mode" value="ferry" />
+            <param name="constant" value="-1" />
+            <param name="marginalUtilityOfDistance_util_m" value="0.0" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="-2" />
+            <param name="monetaryDistanceRate" value="-0.00036832" />
+         </parameterset>
+         <!-- presently same attributes as bus -->
+         <parameterset type="modeParams">
+            <param name="mode" value="cablecar" />
+            <param name="constant" value="-1" />
+            <param name="marginalUtilityOfDistance_util_m" value="0.0" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="-2" />
+            <param name="monetaryDistanceRate" value="-0.00036832" />
+         </parameterset>
+         <!-- Made it expensive -->
+         <parameterset type="modeParams">
+            <param name="mode" value="aircraft" />
+            <param name="constant" value="-1" />
+            <param name="marginalUtilityOfDistance_util_m" value="0.0" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="-200" />
+            <param name="monetaryDistanceRate" value="-0.00036832" />
+         </parameterset>
+      </parameterset>
+      <parameterset type="scoringParameters">
+         <param name="earlyDeparture" value="-0.0" />
+         <param name="lateArrival" value="-50" />
+         <param name="marginalUtilityOfMoney" value="10" />
+         <param name="performing" value="100" />
+         <param name="subpopulation" value="hhs_carAvailnever" />
+         <param name="utilityOfLineSwitch" value="-5" />
+         <param name="waiting" value="-0.0" />
+         <param name="waitingPt" value="0" />
+         <parameterset type="activityParams">
+            <param name="activityType" value="home" />
+            <param name="openingTime" value="undefined" />
+            <param name="closingTime" value="undefined" />
+            <param name="earliestEndTime" value="undefined" />
+            <param name="latestStartTime" value="undefined" />
+            <param name="minimalDuration" value="1:00:00" />
+            <param name="typicalDuration" value="8:00:00" />
+            <param name="priority" value="1.0" />
+            <param name="scoringThisActivityAtAll" value="true" />
+            <param name="typicalDurationScoreComputation" value="relative" />
+         </parameterset>
+         <parameterset type="activityParams">
+            <param name="activityType" value="work" />
+            <param name="openingTime" value="7:00:00" />
+            <param name="closingTime" value="19:30:00" />
+            <param name="earliestEndTime" value="undefined" />
+            <param name="latestStartTime" value="undefined" />
+            <param name="minimalDuration" value="6:00:00" />
+            <param name="typicalDuration" value="8:30:00" />
+            <param name="priority" value="1.0" />
+            <param name="scoringThisActivityAtAll" value="true" />
+            <param name="typicalDurationScoreComputation" value="relative" />
+         </parameterset>
+         <parameterset type="activityParams">
+            <param name="activityType" value="shop" />
+            <param name="openingTime" value="08:30:00" />
+            <param name="closingTime" value="17:30:00" />
+            <param name="earliestEndTime" value="undefined" />
+            <param name="latestStartTime" value="undefined" />
+            <param name="minimalDuration" value="0:10:00" />
+            <param name="typicalDuration" value="0:30:00" />
+            <param name="priority" value="1.0" />
+            <param name="scoringThisActivityAtAll" value="true" />
+            <param name="typicalDurationScoreComputation" value="relative" />
+         </parameterset>
+         <parameterset type="activityParams">
+            <param name="activityType" value="visit"/>
+            <param name="openingTime" value="undefined"/>
+            <param name="closingTime" value="undefined"/>
+            <param name="earliestEndTime" value="undefined"/>
+            <param name="latestStartTime" value="undefined"/>
+            <param name="minimalDuration" value="0:30:00"/>
+            <param name="typicalDuration" value="2:00:00"/>
+            <param name="priority" value="1.0"/>
+            <param name="scoringThisActivityAtAll" value="true"/>
+            <param name="typicalDurationScoreComputation" value="relative"/>
+         </parameterset>
+         <!-- borrowed from visit -->
+         <parameterset type="activityParams">
+            <param name="activityType" value="left_country"/>
+            <param name="openingTime" value="undefined"/>
+            <param name="closingTime" value="undefined"/>
+            <param name="earliestEndTime" value="undefined"/>
+            <param name="latestStartTime" value="undefined"/>
+            <param name="minimalDuration" value="0:30:00"/>
+            <param name="typicalDuration" value="2:00:00"/>
+            <param name="priority" value="1.0"/>
+            <param name="scoringThisActivityAtAll" value="true"/>
+            <param name="typicalDurationScoreComputation" value="relative"/>
+         </parameterset>
+         <parameterset type="activityParams">
+            <param name="activityType" value="education" />
+            <param name="openingTime" value="08:30:00" />
+            <param name="closingTime" value="17:00:00" />
+            <param name="earliestEndTime" value="undefined" />
+            <param name="latestStartTime" value="undefined" />
+            <param name="minimalDuration" value="6:00:00" />
+            <param name="typicalDuration" value="6:00:00" />
+            <param name="priority" value="1.0" />
+            <param name="scoringThisActivityAtAll" value="true" />
+            <param name="typicalDurationScoreComputation" value="relative" />
+         </parameterset>
+         <parameterset type="activityParams">
+            <param name="activityType" value="recreation" />
+            <param name="openingTime" value="06:00:00" />
+            <param name="closingTime" value="23:00:00" />
+            <param name="earliestEndTime" value="undefined" />
+            <param name="latestStartTime" value="undefined" />
+            <param name="minimalDuration" value="0:30:00" />
+            <param name="typicalDuration" value="2:00:00" />
+            <param name="priority" value="1.0" />
+            <param name="scoringThisActivityAtAll" value="true" />
+            <param name="typicalDurationScoreComputation" value="relative" />
+         </parameterset>
+         <parameterset type="activityParams">
+            <param name="activityType" value="escort" />
+            <param name="openingTime" value="08:30:00" />
+            <param name="closingTime" value="17:30:00" />
+            <param name="earliestEndTime" value="undefined" />
+            <param name="latestStartTime" value="undefined" />
+            <param name="minimalDuration" value="0:05:00" />
+            <param name="typicalDuration" value="0:15:00" />
+            <param name="priority" value="1.0" />
+            <param name="scoringThisActivityAtAll" value="true" />
+            <param name="typicalDurationScoreComputation" value="relative" />
+         </parameterset>
+         <parameterset type="activityParams">
+            <param name="activityType" value="other" />
+            <param name="openingTime" value="07:00:00" />
+            <param name="closingTime" value="23:00:00" />
+            <param name="earliestEndTime" value="undefined" />
+            <param name="latestStartTime" value="undefined" />
+            <param name="minimalDuration" value="0:10:00" />
+            <param name="typicalDuration" value="0:30:00" />
+            <param name="priority" value="1.0" />
+            <param name="scoringThisActivityAtAll" value="true" />
+            <param name="typicalDurationScoreComputation" value="relative" />
+         </parameterset>
+        <!-- hhs_carAvailnever subpop, so car is taxi'esque in terms of its cost (currently 10x)        -->
+         <parameterset type="modeParams">
+            <param name="constant" value="-20" />
+            <param name="marginalUtilityOfDistance_util_m" value="0.0" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="-0.0" />
+            <param name="mode" value="car" />
+            <param name="monetaryDistanceRate" value="-0.0001" />
+         </parameterset>
+         <parameterset type="modeParams">
+            <param name="constant" value="-20" />
+            <param name="dailyMonetaryConstant" value="0" />
+            <param name="dailyUtilityConstant" value="0.0" />
+            <param name="marginalUtilityOfDistance_util_m" value="-0.1" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="0" />
+            <param name="mode" value="bike" />
+            <param name="monetaryDistanceRate" value="-0.0" />
+         </parameterset>
+         <parameterset type="modeParams">
+            <param name="constant" value="-0" />
+            <param name="marginalUtilityOfDistance_util_m" value="-0.01" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="0" />
+            <param name="mode" value="walk" />
+            <param name="monetaryDistanceRate" value="0.0" />
+         </parameterset>
+         <parameterset type="modeParams">
+            <param name="mode" value="pt" />
+            <param name="constant" value="-1000.0" />
+            <param name="marginalUtilityOfDistance_util_m" value="0.0" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="-1" />
+            <param name="monetaryDistanceRate" value="-0.000" />
+         </parameterset>
+         <parameterset type="modeParams">
+            <param name="mode" value="bus" />
+            <param name="constant" value="-1" />
+            <param name="marginalUtilityOfDistance_util_m" value="0.0" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="-2" />
+            <param name="monetaryDistanceRate" value="-0.00036832" />
+         </parameterset>
+         <parameterset type="modeParams">
+            <param name="mode" value="rail" />
+            <param name="constant" value="-1" />
+            <param name="marginalUtilityOfDistance_util_m" value="0.0" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="-1" />
+            <param name="monetaryDistanceRate" value="-0.00011177" />
+         </parameterset>
+         <!-- presently same attributes as bus -->
+         <parameterset type="modeParams">
+            <param name="mode" value="ferry" />
+            <param name="constant" value="-1" />
+            <param name="marginalUtilityOfDistance_util_m" value="0.0" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="-2" />
+            <param name="monetaryDistanceRate" value="-0.00036832" />
+         </parameterset>
+         <!-- presently same attributes as bus -->
+         <parameterset type="modeParams">
+            <param name="mode" value="cablecar" />
+            <param name="constant" value="-1" />
+            <param name="marginalUtilityOfDistance_util_m" value="0.0" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="-2" />
+            <param name="monetaryDistanceRate" value="-0.00036832" />
+         </parameterset>
+         <!-- Made it expensive -->
+         <parameterset type="modeParams">
+            <param name="mode" value="aircraft" />
+            <param name="constant" value="-1" />
+            <param name="marginalUtilityOfDistance_util_m" value="0.0" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="-200" />
+            <param name="monetaryDistanceRate" value="-0.00036832" />
+         </parameterset>
+      </parameterset>
+      <parameterset type="scoringParameters">
+         <param name="earlyDeparture" value="-0.0" />
+         <param name="lateArrival" value="-50" />
+         <param name="marginalUtilityOfMoney" value="10" />
+         <param name="performing" value="100" />
+         <param name="subpopulation" value="hgv" />
+         <param name="utilityOfLineSwitch" value="-5" />
+         <param name="waiting" value="-0.0" />
+         <param name="waitingPt" value="0" />
+         <parameterset type="activityParams">
+            <param name="activityType" value="depot" />
+            <param name="openingTime" value="undefined" />
+            <param name="closingTime" value="undefined" />
+            <param name="earliestEndTime" value="undefined" />
+            <param name="latestStartTime" value="undefined" />
+            <param name="minimalDuration" value="undefined" />
+            <param name="typicalDuration" value="12:00:00" />
+            <param name="priority" value="1.0" />
+            <param name="scoringThisActivityAtAll" value="true" />
+            <param name="typicalDurationScoreComputation" value="relative" />
+         </parameterset>
+         <parameterset type="activityParams">
+            <param name="activityType" value="delivery" />
+            <param name="openingTime" value="6:00:00" />
+            <param name="closingTime" value="20:00:00" />
+            <param name="earliestEndTime" value="undefined" />
+            <param name="latestStartTime" value="undefined" />
+            <param name="minimalDuration" value="00:20:00" />
+            <param name="typicalDuration" value="01:00:00" />
+            <param name="priority" value="1.0" />
+            <param name="scoringThisActivityAtAll" value="true" />
+            <param name="typicalDurationScoreComputation" value="relative" />
+         </parameterset>
+         <parameterset type="modeParams">
+            <param name="constant" value="-20" />
+            <param name="marginalUtilityOfDistance_util_m" value="-0.0" />
+            <param name="marginalUtilityOfTraveling_util_hr" value="-0.0" />
+            <param name="mode" value="car" />
+            <param name="monetaryDistanceRate" value="-0.0001" />
+         </parameterset>
+      </parameterset>
+   </module>
+   <!-- these are the innovation strategies 
+	defined per subpop -->
+   <module name="strategy">
+      <param name="ExternalExeConfigTemplate" value="null" />
+      <param name="ExternalExeTimeOut" value="3600" />
+      <param name="ExternalExeTmpFileRootDir" value="null" />
+      <param name="fractionOfIterationsToDisableInnovation" value="0.9" />
+      <param name="maxAgentPlanMemorySize" value="5" />
+      <param name="planSelectorForRemoval" value="WorstPlanSelector" />
+      <!-- default -->
+      <parameterset type="strategysettings">
+         <param name="disableAfterIteration" value="-1" />
+         <param name="executionPath" value="null" />
+         <param name="strategyName" value="ReRoute" />
+         <param name="subpopulation" value="default" />
+         <param name="weight" value="0.1" />
+      </parameterset>
+      <parameterset type="strategysettings">
+         <param name="disableAfterIteration" value="-1" />
+         <param name="executionPath" value="null" />
+         <param name="strategyName" value="SubtourModeChoice" />
+         <param name="subpopulation" value="default" />
+         <param name="weight" value="0.4" />
+      </parameterset>
+      <parameterset type="strategysettings">
+         <param name="disableAfterIteration" value="-1" />
+         <param name="executionPath" value="null" />
+         <param name="strategyName" value="TimeAllocationMutator_ReRoute" />
+         <param name="subpopulation" value="default" />
+         <param name="weight" value="0.2" />
+      </parameterset>
+      <parameterset type="strategysettings">
+         <param name="disableAfterIteration" value="-1" />
+         <param name="executionPath" value="null" />
+         <param name="strategyName" value="ChangeExpBeta" />
+         <param name="subpopulation" value="default" />
+         <param name="weight" value="0.3" />
+      </parameterset>
+      <!-- hhs_carAvailyes -->
+      <parameterset type="strategysettings">
+         <param name="disableAfterIteration" value="-1" />
+         <param name="executionPath" value="null" />
+         <param name="strategyName" value="ReRoute" />
+         <param name="subpopulation" value="hhs_carAvailyes" />
+         <param name="weight" value="0.1" />
+      </parameterset>
+      <parameterset type="strategysettings">
+         <param name="disableAfterIteration" value="-1" />
+         <param name="executionPath" value="null" />
+         <param name="strategyName" value="SubtourModeChoice" />
+         <param name="subpopulation" value="hhs_carAvailyes" />
+         <param name="weight" value="0.4" />
+      </parameterset>
+      <parameterset type="strategysettings">
+         <param name="disableAfterIteration" value="-1" />
+         <param name="executionPath" value="null" />
+         <param name="strategyName" value="TimeAllocationMutator_ReRoute" />
+         <param name="subpopulation" value="hhs_carAvailyes" />
+         <param name="weight" value="0.2" />
+      </parameterset>
+      <parameterset type="strategysettings">
+         <param name="disableAfterIteration" value="-1" />
+         <param name="executionPath" value="null" />
+         <param name="strategyName" value="ChangeExpBeta" />
+         <param name="subpopulation" value="hhs_carAvailyes" />
+         <param name="weight" value="0.3" />
+      </parameterset>
+      <!-- hhs_carAvailnever -->
+      <parameterset type="strategysettings">
+         <param name="disableAfterIteration" value="-1" />
+         <param name="executionPath" value="null" />
+         <param name="strategyName" value="ReRoute" />
+         <param name="subpopulation" value="hhs_carAvailnever" />
+         <param name="weight" value="0.1" />
+      </parameterset>
+      <parameterset type="strategysettings">
+         <param name="disableAfterIteration" value="-1" />
+         <param name="executionPath" value="null" />
+         <param name="strategyName" value="SubtourModeChoice" />
+         <param name="subpopulation" value="hhs_carAvailnever" />
+         <param name="weight" value="0.4" />
+      </parameterset>
+      <parameterset type="strategysettings">
+         <param name="disableAfterIteration" value="-1" />
+         <param name="executionPath" value="null" />
+         <param name="strategyName" value="TimeAllocationMutator_ReRoute" />
+         <param name="subpopulation" value="hhs_carAvailnever" />
+         <param name="weight" value="0.2" />
+      </parameterset>
+      <parameterset type="strategysettings">
+         <param name="disableAfterIteration" value="-1" />
+         <param name="executionPath" value="null" />
+         <param name="strategyName" value="ChangeExpBeta" />
+         <param name="subpopulation" value="hhs_carAvailnever" />
+         <param name="weight" value="0.3" />
+      </parameterset>
+      <!-- hgv -->
+      <parameterset type="strategysettings">
+         <param name="disableAfterIteration" value="-1" />
+         <param name="executionPath" value="null" />
+         <param name="strategyName" value="ReRoute" />
+         <param name="subpopulation" value="hgv" />
+         <param name="weight" value="0.3" />
+      </parameterset>
+      <parameterset type="strategysettings">
+         <param name="disableAfterIteration" value="-1" />
+         <param name="executionPath" value="null" />
+         <param name="strategyName" value="TimeAllocationMutator_ReRoute" />
+         <param name="subpopulation" value="hgv" />
+         <param name="weight" value="0.3" />
+      </parameterset>
+      <parameterset type="strategysettings">
+         <param name="disableAfterIteration" value="-1" />
+         <param name="executionPath" value="null" />
+         <param name="strategyName" value="ChangeExpBeta" />
+         <param name="subpopulation" value="hgv" />
+         <param name="weight" value="0.4" />
+      </parameterset>
+   </module>
+</config>


### PR DESCRIPTION
 In the `scoringParameter` section in the matsim config, sometimes the `mode`  in `modeParams` for different subpopulations is not consistent with the subpopulations. e.g for `hgv` only has `car` as the  `modeParams`. 

This PR fixed this inconsistency bug when requiring the scoring values for various modes in different subpopulations by returning the None if the mode is not found in this subpopulation. 

```
=======================================parameters for scoring=======================================
===========================================subpopulation============================================
subpopulation: default,hhs_carAvailyes,hhs_carAvailnever,hgv,
=======scoring parameters for subpopulation=======
marginalUtilityOfMoney:10,10,10,10,
performing:100,100,100,100,
---------------------mode:bus---------------------
mode_specific_constant:-1,-1,-1,NA
marginal_utility_of_distance:0.0,0.0,0.0,NA
marginal_utility_of_traveling:-2,-2,-2,NA
monetary_distance_rate:-0.00036832,-0.00036832,-0.00036832,NA
```

Add a date at the head of log. 

Add a more realistic NZ matsim config for testing in the future. 

The updated mc has been tested via bitsim orchestration in the NZ project. 