### PR TITLE
stop filling docker image with superfluous files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+venv/
+reports/
+scripts/
+tests/
+
+mc.egg-info/
+.github
+.coverage
+.gitignore
+.dockerignore
+
+Dockerfile
+*.md


### PR DESCRIPTION
The `Dockerfile` uses the rather heavy-handed `COPY . .` which means the entire repo gets sent to the docker daemon as build context and ultimately included in the final image. It's possibly and sometimes preferable to specify only files required (explicit include) but this approach of explicit exclude using a `.dockerignore` also solves most of the problem and doesn't affect the existing build process at all.

This may be something worth checking across other repos, although I assume @mfitz has done that with any other images for which size was a concern.

**Before adding a `.dockerignore`:**
 
![Screenshot 2022-02-22 at 16 29 22](https://user-images.githubusercontent.com/10106219/155175755-b7471b43-85c5-4b05-b909-99ff2b002348.png)

![Screenshot 2022-02-22 at 16 22 59](https://user-images.githubusercontent.com/10106219/155175445-132f1946-aa90-4015-9a30-24f3b697efb1.png)

**After adding a `.dockerignore`:**

![Screenshot 2022-02-22 at 16 29 42](https://user-images.githubusercontent.com/10106219/155175782-18d77711-2b08-465e-bb3a-c817d21b792f.png)

![Screenshot 2022-02-22 at 16 23 15](https://user-images.githubusercontent.com/10106219/155175501-28de13f6-8c0e-4d1c-9cdf-de9bcbdca5d4.png)

