### PR TITLE
extend and correct language-specific code block formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Modify, generate, diff and debug configs from the command line.
 
 MC requires python3.5 or above.
 
-```{bash}
-git@github.com:arup-group/mc.git
+```sh
+git clone git@github.com:arup-group/mc.git
+pip3 install -e .
 cd mc
 virtualenv -p python3.7 venv
 source venv/bin/activate
@@ -44,7 +45,7 @@ We are also interested in maintaining a `debug` command to catch common config m
 
 The CLI commands are pretty explorable via help, start with `mc --help`:
 
-```{bash}
+```sh
 Usage: mc [OPTIONS] COMMAND [ARGS]...
 
   Command line interface for MC.
@@ -71,11 +72,11 @@ Commands:
 
 (from MC root)
 
-```{bash}
+```sh
 ❯ mc print tests/test_data/test_config.xml
 ```
 
-```{bash}
+```sh
 module {'name': 'global'}
    param {'name': 'coordinateSystem', 'value': 'EPSG:27700'}
    param {'name': 'insistingOnDeprecatedConfigVersion', 'value': 'true'}
@@ -94,11 +95,11 @@ module {'name': 'global'}
 
 (from MC root)
 
-```{bash}
+```sh
 ❯ mc diff tests/test_data/test_config.xml tests/test_data/test_config_v12.xml
 ```
 
-```{bash}
+```sh
 - param@plans: insistingOnUsingDeprecatedPersonAttributeFile
 - param@plans: inputPersonAttributesFile
 +/- param@strategy: fractionOfIterationsToDisableInnovation: 0.95 -> 0.9
@@ -108,11 +109,11 @@ module {'name': 'global'}
 
 (from MC root)
 
-```{bash}
+```sh
 ❯ mc find tests/test_data/test_config.xml coordinateSystem
 ```
 
-```{bash}
+```sh
 param {'name': 'coordinateSystem', 'value': 'EPSG:27700'}
 ```
 
@@ -120,20 +121,20 @@ You can read about more complex addressing in [Find](##find).
 
 ## Programming Interface
 
-```{python}
+```py
 from mc import build
 ```
 
 To facilitate a beautiful future where humans never need edit xml and machines start to explore MATSim simulation config parameter spaces themselves, MC makes a dictionary-like `mc.build.Config` object available. `Config` objects can read and write to MATSim `.xml` config format (and `.json` just in case).
 
-```{python}
+```py
 config = build.Config(path='tests/test_data/test_config.xml')
 config.write(path='temp.json')
 config2 = build.Config(path='temp.json')
 config == config2
 ```
 
-```{python}
+```py
 True
 ```
 
@@ -145,25 +146,24 @@ MATSim configs consist of modules, these modules can contain either parameters a
 
 `Config` objects consist of nested `Modules`, `ParamSets` and `Params` (just like a MATSim xml formatted config). All of which will behave like a nested set of dicts. Icluding supporting getting and setting methods:
 
-```{python}
+```py
 # get and print module contents:
 config['plans'].print()
 ```
 
-```{python}
+```py
 module {'name': 'plans'}
     param {'name': 'inputPlansFile', 'value': 'test_inputs/population.xml'}
     param {'name': 'inputPersonAttributesFile', 'value': 'test_inputs/attributes.xml'}
     param {'name': 'subpopulationAttributeName', 'value': 'subpopulation'}
 ```
 
-```{python}
+```py
  # set and print a single param:
 config['plans']['inputPlansFile'] = 'test_inputs/new_population.xml'
 print(config['plans']['inputPlansFile'])
 ```
-
-```{python}
+```py
 test_inputs/new_population.xml
 ```
 
@@ -172,14 +172,14 @@ test_inputs/new_population.xml
 Nested setting is allowed, for example for an empty `Config` a new module, paramset and param
  can be set together:
 
-```{python}
+```py
 empty_config = build.Config()
 empty_config['global']['coordinateSystem'] = 'EPSG:27700'
 ...
 empty_config.print()
 ```
 
-```{python}
+```py
 module {'name': 'global'}
     param {'name': 'coordinateSystem', 'value': 'EPSG:27700'}
 ```
@@ -188,24 +188,24 @@ module {'name': 'global'}
 
 Setting requires that keys are valid:
 
-```{python}
+```py
 empty_config = build.Config()
 empty_config['NotAModule']['coordinateSystem'] = 'EPSG:27700'
 ```
 
-```{python}
+```py
 ...
 KeyError: "key:'NotAModule' not found in modules"
 ```
 
 ...and that values are valid:
 
-```{python}
+```py
 empty_config['global']['coordinateSystem'] = {"crs": "27700"}
 
 ```
 
-```{python}
+```py
 INFO creating new empty module: global
 ValueError: Please use value of either type ParamSet, Param or str
 ```
@@ -218,12 +218,12 @@ objects via `.valid_keys`. Note that valid keys and values are hardcoded in `mc.
 MATSim configurations include parameter***sets*** for which the unique identification (such as the mode or subpopulation) is contained as a parameter. So that we can provide unique keys for the parameter***set***, we therefore suffix parameter***set*** keys as `<paramset_name>:<uid>` where `uid` is the appropriate parameterset
 subpopulation, mode or activity:
 
-```{python}
+```py
 empty_config.write(path=Path('temp.xml'))
 empty_config['planCalcScore']['scoringParameters:high_income']['modeParams:car']['monetaryDistanceRate'] = '-0.0001'
 ```
 
-```{python}
+```py
 INFO creating new empty module: planCalcScore
 INFO creating new empty parameterset: scoringParameters:high_income
 INFO creating new empty parameterset: modeParams:car
@@ -240,40 +240,40 @@ an existing config, these suffixes are automatically generated.
 
 Both the CLI and API support searches for config components using an addressing system. The addressing system uses a string format with `/` to denote a nested parameterset or parameter. This allows changes to be easilly passed as commands via common web interfaces for example.
 
-```{python}
+```py
 config = build.Config(path='tests/test_data/test_config.xml')
 search = config.find("plans/inputPlansFile")
 for i in search:
   i.print()
 ```
 
-```{python}
+```py
 param {'name': 'inputPlansFile', 'value': '~/test/population.xml.gz'}
 ```
 
 Find is returning a list because it supports partial addresses which result in multiple finds:
 
-```{python}
+```py
 search = config.find("modeParams:car/monetaryDistanceRate")
 for i in search:
   i.print()
 ```
 
-```{python}
+```py
 param {'name': 'monetaryDistanceRate', 'value': '-0.0001'}  # eg subpopulation A
 param {'name': 'monetaryDistanceRate', 'value': '-0.0001'}  # eg subpopulation B
 ```
 
 Addresses can omit components, for example if we want to look at all `monetaryDistanceRates` for the default subpopulation (ie from `scoringParameters:default`):
 
-```{python}
+```py
 search = config.find("scoringParameters:default/monetaryDistanceRate")
 # this is equivalent to "*/scoringParameters:default/*/monetaryDistanceRate"
 for i in search:
   i.print()
 ```
 
-```{python}
+```py
 param {'name': 'monetaryDistanceRate', 'value': '-0.0'}  # eg walk
 param {'name': 'monetaryDistanceRate', 'value': '-0.0'}  # eg bike
 param {'name': 'monetaryDistanceRate', 'value': '-0.001'}  # eg pt
@@ -282,7 +282,7 @@ param {'name': 'monetaryDistanceRate', 'value': '-0.0001'}  # eg car
 
 Or more simply we can get all `monetaryDistanceRates`:
 
-```{python}
+```py
 search = config.find("monetaryDistanceRate")
 # this is equivalent to "*/*/*/monetaryDistanceRate"
 # this is equivalnet to "*/scoringParameters:*/modeParams:*/monetaryDistanceRate"
@@ -290,7 +290,7 @@ for i in search:
   i.print()
 ```
 
-```{python}
+```py
 param {'name': 'monetaryDistanceRate', 'value': '-0.0'}  # eg subpop A walk
 param {'name': 'monetaryDistanceRate', 'value': '-0.0'}  # eg subpop A bike
 param {'name': 'monetaryDistanceRate', 'value': '-0.001'}  # subpop A eg pt
@@ -307,7 +307,7 @@ In the examples above, you can see that wildcarding with `*` can be used to retu
 
 Note that the `find` method is returning a reference to the found config objects, which can then be set:
 
-```{python}
+```py
 config.find("plans/inputPlansFile")[0] = "NEW/PATH"
 ```
 
@@ -315,12 +315,12 @@ config.find("plans/inputPlansFile")[0] = "NEW/PATH"
 
 MC has a built-in representation of a valid config structure, specifically the viable names of modules, parametersets and parameters. When reading in an existing config or adding new components, MC will throw validation errors if the valid config structure is not maintained.
 
-```{python}
+```py
 empty_config = build.Config()
 empty_config['NotAModule']['coordinateSystem'] = 'EPSG:27700'
 ```
 
-```{python}
+```py
 ...
 KeyError: "key:'NotAModule' not found in modules"
 ```
@@ -332,7 +332,7 @@ This system is useful for preventing typos, but has to be
 
 An example of how to update the validation mapping can be seen with the addition of a new `hermes` module:
 
-```{xml}
+```xml
   <module name="hermes" >
       <param name="endTime" value="32:00:00" />
       <param name="flowCapacityFactor" value="0.01" />
@@ -343,7 +343,7 @@ An example of how to update the validation mapping can be seen with the addition
 
 In order to make this hermes module available to MC's validation, the following is added to `mc/valid.py`:
 
-```{json}
+```json
   "hermes": {
       "params": {
             "mainMode": "car",
@@ -356,13 +356,13 @@ In order to make this hermes module available to MC's validation, the following 
 
 ## Tests
 
-```{bash}
+```sh
     python -m pytest -vv tests
 ```
 
 To generate XML & HTML coverage reports to `reports/coverage`:
 
-```{bash}
+```sh
     ./scripts/code-coverage.sh
 ```
 


### PR DESCRIPTION
i can't reopen https://github.com/arup-group/mc/pull/45 but this is addressing the same thing