### PR TITLE
Tweak intermediate cooling

### DIFF
--- a/mc/autostep.py
+++ b/mc/autostep.py
@@ -90,7 +90,7 @@ def construct_override_map_from_tuple(overrides: tuple) -> dict:
     return override_map
 
 
-def set_cooling(config, total_iterations, start_index, step):
+def set_cooling(config, total_iterations, start_index, step, target=20):
     """
     Set fractionOfIterationsToDisableInnovation to 0 if iterations exceeded.
     Otherwise set for lesser of [0.2 * step, 20]
@@ -98,7 +98,7 @@ def set_cooling(config, total_iterations, start_index, step):
     if start_index > total_iterations:  # assume cooling
         set_innovation(config=config, new_fraction="0")
     else:
-        desired_intermediate_cooling_steps = min([(0.2 * step), 20])
+        desired_intermediate_cooling_steps = min([(0.2 * step), target])
         new_fraction = 1 - (desired_intermediate_cooling_steps / step)
         set_innovation(config=config, new_fraction=str(new_fraction))
 

--- a/mc/autostep.py
+++ b/mc/autostep.py
@@ -93,12 +93,12 @@ def construct_override_map_from_tuple(overrides: tuple) -> dict:
 def set_cooling(config, total_iterations, start_index, step):
     """
     Set fractionOfIterationsToDisableInnovation to 0 if iterations exceeded.
-    Otherwise set for lesser of [0.8*step, 10]
+    Otherwise set for lesser of [0.2 * step, 20]
     """
     if start_index > total_iterations:  # assume cooling
         set_innovation(config=config, new_fraction="0")
     else:
-        desired_intermediate_cooling_steps = min([(0.2 * step), 10])
+        desired_intermediate_cooling_steps = min([(0.2 * step), 20])
         new_fraction = 1 - (desired_intermediate_cooling_steps / step)
         set_innovation(config=config, new_fraction=str(new_fraction))
 

--- a/tests/test_autostep.py
+++ b/tests/test_autostep.py
@@ -51,7 +51,7 @@ def test_set_innovation(config):
 
 def test_set_cooling(config, total_iterations, start_index, step, new_fraction):
     assert not config['strategy']['fractionOfIterationsToDisableInnovation'] == new_fraction
-    autostep.set_cooling(config=config, total_iterations=total_iterations, start_index=start_index, step=step)
+    autostep.set_cooling(config=config, total_iterations=total_iterations, start_index=start_index, step=step, target=10)
     assert config['strategy']['fractionOfIterationsToDisableInnovation'] == new_fraction
 
 
@@ -355,7 +355,7 @@ def test_stepping(tmp_path, fake_lambda_handler):
             "scoringParameters:unknown/modeParams:bus/constant", "-1.0"
             )
         )
-    
+
     assert set(os.listdir(tmp_path)) == {"0", "10", "20"}
     for i in range(10, 30, 10):
         out_dir = os.path.join(tmp_path, str(i+10))
@@ -403,7 +403,7 @@ def test_stepping_with_cooling(tmp_path, fake_lambda_handler):
             "scoringParameters:unknown/modeParams:bus/constant", "-1.0"
             )
         )
-    
+
     assert set(os.listdir(tmp_path)) == {"0", "10", "20", "30"}
     for i in range(10, 30, 10):
         out_dir = os.path.join(tmp_path, str(i+10))


### PR DESCRIPTION
FYI

Bitsim uses a mc method in `autostep` to automatically set the amount of "intermediate cooling" by matsim per biteration.

Basically, we try to set `fractionOfIterationsToDisableInnovation` in the matsim strategy such that agents have time to "cool" before progressing to elara for each biteration. Elara then gives us good intermediate and final feedback.

This was previously configured to essentially be 10 iterations, ie for 100 matsim iterations we would set `fractionOfIterationsToDisableInnovation = 0.9`.

However recent work on the 10% HK sim suggests 10 is not enough so I am increasing to 20.

I am wondering if this is a consequence of running big sims (million agents) and/or of our adopting a lower innovation temperature in general (@akay-arup) - such that there is more final plan diversity.

The consequence of this is a greater proportion of matsim time effectivelly wasted. For example, if using biterations for size/step 100, there will be 20% iterations spent cooling.

A response to this might be to increase the size/steps per biteration but this increases risk and also reduces simulation feddback from elara, so there is a trade-off.