### PR TITLE
combine overrides logs

### DIFF
--- a/mc/autostep.py
+++ b/mc/autostep.py
@@ -58,13 +58,23 @@ def autostep_config(
 
     first_iteration = start_index - step
     prev_write_path = sim_root / str(first_iteration)
+    # is_first_iteration = prev_iteration == 0
     last_iteration = start_index
     new_write_path = sim_root / str(last_iteration)
 
-    set_cooling(config=config, total_iterations=total_iterations, start_index=last_iteration, step=step)
+    set_cooling(config=config, total_iterations=total_iterations,
+                start_index=last_iteration, step=step)
     set_write_path(config=config, new_write_path=new_write_path)
-    set_iterations(config=config, first_iteration=first_iteration, last_iteration=last_iteration)
-    find_and_set_overrides(config=config, overrides=overrides, log_root=prev_write_path)
+    set_iterations(config=config, first_iteration=first_iteration,
+                   last_iteration=last_iteration)
+    find_and_set_overrides(
+        config=config, overrides=overrides, log_root=prev_write_path)
+    # if prev_iteration != 0:
+    #     find_and_set_overrides(
+    #         config=config, overrides=overrides, log_root=None)  # as above but without log
+    # else:
+    #     find_and_set_overrides(
+    #         config=config, overrides=overrides, log_root=prev_write_path)
 
     if not first_iteration == 0:  # if first iteration - don't update input paths
         previous_root = sim_root / str(first_iteration)
@@ -82,7 +92,7 @@ def autostep_config(
     # summarise the matsim overrides log information for different executions from the batch file
     file_name = 'matsim_overrides'
     simulation_root_dir = sim_root.parent
-    if first_iteration:
+    if first_iteration == 0:
         summarise_overrides_log(file_name, simulation_root_dir)
 
     logging.info("Autostep complete")
@@ -114,9 +124,11 @@ def set_innovation(config, new_fraction):
     """
     Set config fractionOfIterationsToDisableInnovation.
     """
-    fraction = config['strategy'].get('fractionOfIterationsToDisableInnovation')
+    fraction = config['strategy'].get(
+        'fractionOfIterationsToDisableInnovation')
     config['strategy']['fractionOfIterationsToDisableInnovation'] = new_fraction
-    logging.info(f"Changing fractionOfIterationsToDisableInnovation: {fraction} to: {new_fraction}")
+    logging.info(
+        f"Changing fractionOfIterationsToDisableInnovation: {fraction} to: {new_fraction}")
 
 
 def set_default_behaviours(config: BaseConfig, step: int, seed_matsim_config_path: Path):
@@ -141,7 +153,8 @@ def set_default_behaviours(config: BaseConfig, step: int, seed_matsim_config_pat
     config['planCalcScore']['writeExperiencedPlans'] = "true"
     logging.info("Forcing writeExperiencedPlans to true")
 
-    fix_relative_input_paths_to_abs(config=config, seed_matsim_config_path=seed_matsim_config_path)
+    fix_relative_input_paths_to_abs(
+        config=config, seed_matsim_config_path=seed_matsim_config_path)
 
 
 def set_write_path(config: BaseConfig, new_write_path: Path) -> None:
@@ -151,7 +164,8 @@ def set_write_path(config: BaseConfig, new_write_path: Path) -> None:
     logging.info("Write path override to config")
     old_write_path = Path(config['controler']['outputDirectory'])
     config['controler']['outputDirectory'] = str(new_write_path)
-    logging.info(f"Write file path override: {str(old_write_path)} to: {str(new_write_path)}")
+    logging.info(
+        f"Write file path override: {str(old_write_path)} to: {str(new_write_path)}")
 
 
 def auto_set_input_paths(config: BaseConfig, root: Path) -> None:
@@ -171,7 +185,8 @@ def auto_set_input_paths(config: BaseConfig, root: Path) -> None:
     ]:
         prev_path = config[module][param]
         new_path = root / default
-        logging.info(f"Input ({param}) file path override: {str(prev_path)} to: {str(new_path)}")
+        logging.info(
+            f"Input ({param}) file path override: {str(prev_path)} to: {str(new_path)}")
         config[module][param] = str(new_path)
 
 
@@ -186,9 +201,11 @@ def fix_relative_input_paths_to_abs(config: BaseConfig, seed_matsim_config_path:
         prev_path = Path(config[module][param])
         if not prev_path.is_absolute():
             new_path = Path(os.path.join(
-                os.path.dirname(seed_matsim_config_path), os.path.expanduser(prev_path)
+                os.path.dirname(
+                    seed_matsim_config_path), os.path.expanduser(prev_path)
             )).resolve()
-            logging.info(f"Input ({param}) file path override: {str(prev_path)} to: {str(new_path)}")
+            logging.info(
+                f"Input ({param}) file path override: {str(prev_path)} to: {str(new_path)}")
             config[module][param] = str(new_path)
 
 
@@ -199,10 +216,12 @@ def set_iterations(config: BaseConfig, first_iteration: int, last_iteration: int
     logging.info("Step overrides to config")
     old_firstIteration = config['controler']['firstIteration']
     config['controler']['firstIteration'] = str(first_iteration)
-    logging.info(f"firstIteration (step) override: {old_firstIteration} to: {first_iteration}")
+    logging.info(
+        f"firstIteration (step) override: {old_firstIteration} to: {first_iteration}")
     old_lastIteration = config['controler']['lastIteration']
     config['controler']['lastIteration'] = str(last_iteration)
-    logging.info(f"lastIteration (step) override: {old_lastIteration} to: {last_iteration}")
+    logging.info(
+        f"lastIteration (step) override: {old_lastIteration} to: {last_iteration}")
 
 
 def find_and_set_overrides(config: BaseConfig, overrides: dict, log_root=None) -> None:

--- a/mc/autostep.py
+++ b/mc/autostep.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from mc.base import BaseConfig, Param
 from mc.logger import logging
-from mc.summarise import summarise_config
+from mc.summarise import summarise_config, summarise_overrides_log
 
 DEFAULT_MATSIM_CONFIG_NAME = "matsim_config.xml"
 DEFAULT_PLANS_NAME = "output_plans.xml.gz"
@@ -78,6 +78,12 @@ def autostep_config(
     # summarise the key information from matsim config to a text file
     text_log_path = biteration_matsim_config_path.parent
     summarise_config(config, text_log_path)
+
+    # summarise the matsim overrides log information for different executions from the batch file
+    file_name = 'matsim_overrides'
+    simulation_root_dir = sim_root.parent
+    if first_iteration:
+        summarise_overrides_log(file_name, simulation_root_dir)
 
     logging.info("Autostep complete")
 

--- a/mc/summarise.py
+++ b/mc/summarise.py
@@ -47,7 +47,7 @@ def scoring_summary(config):
                       "marginal_utility_of_distance:",
                       "marginal_utility_of_traveling:",
                       "monetary_distance_rate:"]
-    # add subpopulation in the score calcualtion
+    # add subpopulation in the score calculation
     subpopulation_set = {}
     subpop = 'subpopulation: '
     for i in config['planCalcScore'].find('subpopulation'):
@@ -106,3 +106,35 @@ def write_text(text, output_path):
 def summarise_config(config, output_path):
     text = scoring_summary(config)
     write_text(text, output_path)
+
+
+def find_log_files(file_name, root_dir):
+    """
+    Find the path for log files for the jobs from different simulation jobs
+    """
+    file_directory = []
+    for root, dirs, files in os.walk(root_dir):
+        for file in files:
+            if file.startswith(file_name):
+                if str(root)[-2:] == '/0':  # find the file in zero iteration only in the simulation folder
+                    file_directory.append(os.path.join(root, file))
+    return file_directory
+
+
+def merge_files(file_directory, root_dir):
+    """
+    Combine and update the matsim_overrides log from different simulation jobs
+    """
+    with open(os.path.join(root_dir, 'matsim_overrides_summary.log'), "w") as outfile:
+        for f in file_directory:
+            with open(f) as infile:
+                text = infile.readlines()
+                text.insert(0, f + "\n")
+                text.insert(0, "log_path:")
+                text.insert(0, "-" * 100 + '\n')  # split line
+                outfile.write(''.join(text))
+
+
+def summarise_overrides_log(file_name, root_dir):
+    file_directory = find_log_files(file_name, root_dir)
+    merge_files(file_directory, root_dir)


### PR DESCRIPTION
Some works followed by the [PR adds overrides log#48](https://github.com/arup-group/mc/pull/48).

Add functions that find all of `matsim_overrides.log` from various simulations submitted via the bitsim batch file and merge all of the logs at 0 iterations into a `matsim_overrides_summary`. The summary override log is saved in the simulation root directory. 

Examples should like: 
```
----------------------------------------------------------------------------------------------------
log_path:/mnt/efs/simulation_name1/0/matsim_overrides.log
flowCapacityFactor: 1 -> 0.01
modeParams:car/constant: 0.0 -> -50
modeParams:car/constant: 0.0 -> -50
----------------------------------------------------------------------------------------------------
log_path:/mnt/efs/simulation_name2/0/matsim_overrides.log
flowCapacityFactor: 1 -> 0.02
modeParams:car/constant: 0.0 -> -50
modeParams:car/constant: 0.0 -> -50
```
Will test it in bitsim.