### PR TITLE
Fix the package list in setup script

### DIFF
--- a/mc/__init__.py
+++ b/mc/__init__.py
@@ -5,7 +5,7 @@ import os
 from pathlib import Path
 
 
-__version__ = "0.0.0"
+__version__ = "1.0.0"
 _ROOT = Path(os.path.abspath(os.path.dirname(__file__)))
 
 _DEFAULTS_DIR = _ROOT / 'default_data'

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     name="mc",
     version=__version__,
     description="A command line tool for using MATSim config files.",
-    packages=find_packages(exclude="tests*"),
+    packages=find_packages(exclude=["tests*"]),
     install_requires=install_requires,
     entry_points={"console_scripts": ["mc = mc.cli:cli"]},
 )


### PR DESCRIPTION
Whilst trying to include MC as a dependency in another project (`scop`), I happened upon a weird error. The project's `requirements.txt` looked like this:
```bash
...
mc@https://github.com/arup-group/mc/archive/refs/tags/v1.0.0-snapshot.tar.gz#egg=1.0.0
...
```
After `pip install -r requirements.txt`, all looked well:
```bash
$ pip show mc

Name: mc
Version: 0.0.0
Summary: A command line tool for using MATSim config files.
Home-page: UNKNOWN
Author: UNKNOWN
Author-email: UNKNOWN
License: UNKNOWN
Location: /Users/mickyfitz/.pyenv/versions/3.7.6/envs/scop-3.7.6/lib/python3.7/site-packages
Requires: Click, flake8, lxml, pytest, pytest-cov, setuptools, typing
Required-by:
```

And yet, when I tried to `import mc`:
```bash
$ python

Python 3.7.6 (default, Feb 19 2020, 11:47:00)
[Clang 10.0.0 (clang-1000.10.44.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import lxml
>>> import mc
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'mc'
```

Inspecting the location `mc` should have been installed into revealed the metadata (`mc-0.0.0.dist-info`), but no actual `mc` package, which explained why I could not import it:
```bash
$ lt /Users/mickyfitz/.pyenv/versions/3.7.6/envs/scop-3.7.6/lib/python3.7/site-packages | grep mc
drwxr-xr-x  11 mickyfitz  staff   352B  7 Apr 21:47 mc-0.0.0.dist-info
drwxr-xr-x  10 mickyfitz  staff   320B  7 Apr 21:16 mccabe-0.6.1.dist-info
-rw-r--r--   1 mickyfitz  staff    10K  7 Apr 21:16 mccabe.py
```

[This Stack Overflow answer](https://stackoverflow.com/a/54357929/16935877) provided some information on how to go about debugging this, which led me to look at the `packages=` parameter in MC's `setup.py::setup()`. It turns out that the call to `find_packages(exclude="tests*")` is returning an empty list:
```bash
$ python
Python 3.7.6 (default, Feb 19 2020, 11:47:00)
[Clang 10.0.0 (clang-1000.10.44.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.

>>> from setuptools import find_packages
>>> find_packages()
['mc']
>>> find_packages(exclude="tests*")
[]

# the solution
>>> find_packages(exclude=["tests*"])
['mc']
```

This fix should allow us to pull MC into other projects as a dependency.