### PR TITLE
Loosen test dependency version constraints

### DIFF
--- a/mc/__init__.py
+++ b/mc/__init__.py
@@ -5,7 +5,7 @@ import os
 from pathlib import Path
 
 
-__version__ = "1.0.0"
+__version__ = "1.0.2"
 _ROOT = Path(os.path.abspath(os.path.dirname(__file__)))
 
 _DEFAULTS_DIR = _ROOT / 'default_data'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Click==7.1.2
-flake8==3.9.2
+flake8>=3.0.0
 lxml==4.6.5
-pytest-cov==2.11.1
-pytest==6.2.3
+pytest-cov>=2.0.0
+pytest>=6.0.0
 setuptools==56.0.0
 typing==3.7.4

--- a/scripts/.coveragerc
+++ b/scripts/.coveragerc
@@ -3,4 +3,4 @@ branch = True
 omit = venv/*, tests/*, mc/bitsim/*, mc/setup.py
 
 [report]
-fail_under = 84
+fail_under = 85


### PR DESCRIPTION
When attempting to install `scop`:
<img width="1401" alt="Screen Shot 2022-04-08 at 13 27 46" src="https://user-images.githubusercontent.com/250899/162439450-53bcd2cf-0f1c-4f10-a315-28ff9dd381ac.png">

[I've opened the same kind of PR for genet](https://github.com/arup-group/genet/pull/114), but it seems like now is a good time to do the same here.
