### PR TITLE
#54 fix

### DIFF
--- a/mc/base.py
+++ b/mc/base.py
@@ -34,7 +34,6 @@ class Base:
     class_type = ''
     ident = ''
     name = ''
-    value = ''
     valid_keys = []
     valid_param_keys = []
     valid_paramset_keys = []

--- a/tests/test_base_config.py
+++ b/tests/test_base_config.py
@@ -118,7 +118,7 @@ def test_config_dict_navigation():
     scoringParameters = test_module.parametersets['scoringParameters:default']
     activityParams = scoringParameters.parametersets['activityParams:home']
     activityType = activityParams.params['activityType']
-    assert activityType.data['value'] == 'home'
+    assert activityType.value == 'home'
 
 
 def test_module_dict_get():


### PR DESCRIPTION
Scary fix to remove value copies from happening.

This now works as expected:
```
for param in config.find("address/of/params"):
    param.value = "new_value"
```

Requires removing some inherited methods and replacing with child class specifics. Probably easier to read now though.

Minor improvements to the print method too.

Already has good test coverage but small chance i blew it all up. But must merge to find out 👍🏻 