### PR TITLE
Support all vehicles file

### DIFF
--- a/mc/autostep.py
+++ b/mc/autostep.py
@@ -197,22 +197,25 @@ def auto_set_input_paths(config: BaseConfig, root: Path) -> None:
 
 def fix_relative_input_paths_to_abs(config: BaseConfig, seed_matsim_config_path: Path):
     logging.info("Input path overrides to config")
-    for module, param in [
-        ("network", "inputNetworkFile"),
-        ("plans", "inputPlansFile"),
-        ("transit", "transitScheduleFile"),
-        ("transit", "vehiclesFile"),
-        ("vehicles", "vehiclesFile"),
+    for module, param, optional_in_config in [
+        ("network", "inputNetworkFile", False),
+        ("plans", "inputPlansFile", False),
+        ("transit", "transitScheduleFile", False),
+        ("transit", "vehiclesFile", False),
+        ("vehicles", "vehiclesFile", True),
     ]:
-        prev_path = Path(config[module][param])
-        if not prev_path.is_absolute():
-            new_path = Path(os.path.join(
-                os.path.dirname(
-                    seed_matsim_config_path), os.path.expanduser(prev_path)
-            )).resolve()
-            logging.info(
-                f"Input ({param}) file path override: {str(prev_path)} to: {str(new_path)}")
-            config[module][param] = str(new_path)
+        if (module in config) or not optional_in_config:
+            prev_path = Path(config[module][param])
+            if not prev_path.is_absolute():
+                new_path = Path(os.path.join(
+                    os.path.dirname(
+                        seed_matsim_config_path), os.path.expanduser(prev_path)
+                )).resolve()
+                logging.info(
+                    f"Input ({param}) file path override: {str(prev_path)} to: {str(new_path)}")
+                config[module][param] = str(new_path)
+        else:
+            print(f"Optional module '{module}' was not found in the config")
 
 
 def set_iterations(config: BaseConfig, first_iteration: int, last_iteration: int) -> None:

--- a/mc/autostep.py
+++ b/mc/autostep.py
@@ -181,18 +181,21 @@ def auto_set_input_paths(config: BaseConfig, root: Path) -> None:
     """
 
     logging.info("Input path overrides to config")
-    for module, param, default in [
-        ("network", "inputNetworkFile", DEFAULT_NETWORK_NAME),
-        ("plans", "inputPlansFile", DEFAULT_PLANS_NAME),
-        ("transit", "transitScheduleFile", DEFAULT_TRANSITSCHEDULE_NAME),
-        ("transit", "vehiclesFile", DEFAULT_TRANSITVEHICLES_NAME),
-        ("vehicles", "vehiclesFile", DEFAULT_ALL_VEHICLES_NAME),
+    for module, param, default, optional_in_config in [
+        ("network", "inputNetworkFile", DEFAULT_NETWORK_NAME, False),
+        ("plans", "inputPlansFile", DEFAULT_PLANS_NAME, False),
+        ("transit", "transitScheduleFile", DEFAULT_TRANSITSCHEDULE_NAME, False),
+        ("transit", "vehiclesFile", DEFAULT_TRANSITVEHICLES_NAME, False),
+        ("vehicles", "vehiclesFile", DEFAULT_ALL_VEHICLES_NAME, True),
     ]:
-        prev_path = config[module][param]
-        new_path = root / default
-        logging.info(
-            f"Input ({param}) file path override: {str(prev_path)} to: {str(new_path)}")
-        config[module][param] = str(new_path)
+        if (module in config) or not optional_in_config:
+            prev_path = config[module][param]
+            new_path = root / default
+            logging.info(
+                f"Input ({param}) file path override: {str(prev_path)} to: {str(new_path)}")
+            config[module][param] = str(new_path)
+        else:
+            print(f"Optional module '{module}' was not found in the config")
 
 
 def fix_relative_input_paths_to_abs(config: BaseConfig, seed_matsim_config_path: Path):

--- a/mc/autostep.py
+++ b/mc/autostep.py
@@ -10,6 +10,7 @@ DEFAULT_PLANS_NAME = "output_plans.xml.gz"
 DEFAULT_NETWORK_NAME = "output_network.xml.gz"
 DEFAULT_TRANSITSCHEDULE_NAME = "output_transitSchedule.xml.gz"
 DEFAULT_TRANSITVEHICLES_NAME = "output_transitVehicles.xml.gz"
+DEFAULT_ALL_VEHICLES_NAME = "output_vehicles.xml.gz"
 DEFAULT_FRACTION_OF_ITERATIONS_TO_DISABLE_INNOVATION = 0.8
 
 
@@ -185,6 +186,7 @@ def auto_set_input_paths(config: BaseConfig, root: Path) -> None:
         ("plans", "inputPlansFile", DEFAULT_PLANS_NAME),
         ("transit", "transitScheduleFile", DEFAULT_TRANSITSCHEDULE_NAME),
         ("transit", "vehiclesFile", DEFAULT_TRANSITVEHICLES_NAME),
+        ("vehicles", "vehiclesFile", DEFAULT_ALL_VEHICLES_NAME),
     ]:
         prev_path = config[module][param]
         new_path = root / default
@@ -200,6 +202,7 @@ def fix_relative_input_paths_to_abs(config: BaseConfig, seed_matsim_config_path:
         ("plans", "inputPlansFile"),
         ("transit", "transitScheduleFile"),
         ("transit", "vehiclesFile"),
+        ("vehicles", "vehiclesFile"),
     ]:
         prev_path = Path(config[module][param])
         if not prev_path.is_absolute():

--- a/mc/valid.py
+++ b/mc/valid.py
@@ -73,7 +73,7 @@ VALID_MAP = {
 
         "vehicles": {
             "params": {
-                "vehiclesFile": "./output_vehicles.xml.gz"
+                "vehiclesFile": "null"
             }
         },
 
@@ -385,12 +385,6 @@ VALID_MAP = {
                 "extensionRadius": "100.0",
                 "maxBeelineWalkConnectionDistance": "100.0",
                 "searchRadius": "1000.0"
-            }
-        },
-
-        "vehicles": {
-            "params": {
-                "vehiclesFile": "null"
             }
         },
 

--- a/mc/valid.py
+++ b/mc/valid.py
@@ -71,6 +71,12 @@ VALID_MAP = {
             }
         },
 
+        "vehicles": {
+            "params": {
+                "vehiclesFile": "./output_vehicles.xml.gz"
+            }
+        },
+
         "transit": {
             "params": {
                 "insistingOnUsingDeprecatedPersonAttributeFile": "true",

--- a/tests/test_autostep.py
+++ b/tests/test_autostep.py
@@ -78,6 +78,7 @@ def test_autoset_input_paths(config):
     autostep.auto_set_input_paths(config, Path("test/ing"))
     assert config['network']['inputNetworkFile'] == 'test/ing/output_network.xml.gz'
     assert config['plans']['inputPlansFile'] == 'test/ing/output_plans.xml.gz'
+    assert config['vehicles']['vehiclesFile'] == 'test/ing/output_vehicles.xml.gz'
     assert config['transit']['transitScheduleFile'] == 'test/ing/output_transitSchedule.xml.gz'
     assert config['transit']['vehiclesFile'] == 'test/ing/output_transitVehicles.xml.gz'
 
@@ -209,6 +210,9 @@ def test_autostep_config_first_iteration(tmp_path):
     assert config['plans']['inputPlansFile'] == os.path.abspath(
         os.path.expanduser(os.path.join("~", "test", "population.xml.gz")
     ))
+    assert config['vehicles']['vehiclesFile'] == os.path.abspath(
+        os.path.expanduser(os.path.join("~", "test", "all_vehicles.xml")
+    ))
     assert config['transit']['transitScheduleFile'] == os.path.abspath(
         os.path.expanduser(os.path.join("~", "test", "schedule-merged.xml")
     ))
@@ -243,6 +247,7 @@ def test_autostep_config(tmp_path):
     assert config['controler']['outputDirectory'] == out_dir
     assert config['network']['inputNetworkFile'] == os.path.join(tmp_path, "10", "output_network.xml.gz")
     assert config['plans']['inputPlansFile'] == os.path.join(tmp_path, "10", "output_plans.xml.gz")
+    assert config['vehicles']['vehiclesFile'] == os.path.join(tmp_path, "10", "output_vehicles.xml.gz")
     assert config['transit']['transitScheduleFile'] == os.path.join(tmp_path, "10", "output_transitSchedule.xml.gz")
     assert config['transit']['vehiclesFile'] == os.path.join(tmp_path, "10", "output_transitVehicles.xml.gz")
     assert config['planCalcScore']['scoringParameters:default']['modeParams:car']["constant"] == "-1.0"
@@ -309,6 +314,9 @@ def test_first_two_steps(tmp_path, fake_lambda_handler):
     assert config['plans']['inputPlansFile'] == os.path.abspath(
         os.path.expanduser(os.path.join("~", "test", "population.xml.gz")
     ))
+    assert config['vehicles']['vehiclesFile'] == os.path.abspath(
+        os.path.expanduser(os.path.join("~", "test", "all_vehicles.xml")
+    ))
     assert config['transit']['transitScheduleFile'] == os.path.abspath(
         os.path.expanduser(os.path.join("~", "test", "schedule-merged.xml")
     ))
@@ -343,6 +351,7 @@ def test_first_two_steps(tmp_path, fake_lambda_handler):
     assert config['controler']['outputDirectory'] == out_dir
     assert config['network']['inputNetworkFile'] == os.path.join(tmp_path, "10", "output_network.xml.gz")
     assert config['plans']['inputPlansFile'] == os.path.join(tmp_path, "10", "output_plans.xml.gz")
+    assert config['vehicles']['vehiclesFile'] == os.path.join(tmp_path, "10", "output_vehicles.xml.gz")
     assert config['transit']['transitScheduleFile'] == os.path.join(tmp_path, "10", "output_transitSchedule.xml.gz")
     assert config['transit']['vehiclesFile'] == os.path.join(tmp_path, "10", "output_transitVehicles.xml.gz")
     assert config['planCalcScore']['scoringParameters:default']['modeParams:car']["constant"] == "-1.0"
@@ -390,6 +399,7 @@ def test_stepping(tmp_path, fake_lambda_handler):
         assert config['controler']['outputDirectory'] == out_dir
         assert config['network']['inputNetworkFile'] == os.path.join(tmp_path, str(i), "output_network.xml.gz")
         assert config['plans']['inputPlansFile'] == os.path.join(tmp_path, str(i), "output_plans.xml.gz")
+        assert config['vehicles']['vehiclesFile'] == os.path.join(tmp_path, str(i), "output_vehicles.xml.gz")
         assert config['transit']['transitScheduleFile'] == os.path.join(tmp_path, str(i), "output_transitSchedule.xml.gz")
         assert config['transit']['vehiclesFile'] == os.path.join(tmp_path, str(i), "output_transitVehicles.xml.gz")
         assert config['planCalcScore']['scoringParameters:default']['modeParams:car']["constant"] == "-1.0"
@@ -438,6 +448,7 @@ def test_stepping_with_cooling(tmp_path, fake_lambda_handler):
         assert config['controler']['outputDirectory'] == out_dir
         assert config['network']['inputNetworkFile'] == os.path.join(tmp_path, str(i), "output_network.xml.gz")
         assert config['plans']['inputPlansFile'] == os.path.join(tmp_path, str(i), "output_plans.xml.gz")
+        assert config['vehicles']['vehiclesFile'] == os.path.join(tmp_path, str(i), "output_vehicles.xml.gz")
         assert config['transit']['transitScheduleFile'] == os.path.join(tmp_path, str(i), "output_transitSchedule.xml.gz")
         assert config['transit']['vehiclesFile'] == os.path.join(tmp_path, str(i), "output_transitVehicles.xml.gz")
         assert config['planCalcScore']['scoringParameters:default']['modeParams:car']["constant"] == "-1.0"
@@ -454,6 +465,7 @@ def test_stepping_with_cooling(tmp_path, fake_lambda_handler):
     assert config['controler']['outputDirectory'] == out_dir
     assert config['network']['inputNetworkFile'] == os.path.join(tmp_path, str(i), "output_network.xml.gz")
     assert config['plans']['inputPlansFile'] == os.path.join(tmp_path, str(i), "output_plans.xml.gz")
+    assert config['vehicles']['vehiclesFile'] == os.path.join(tmp_path, str(i), "output_vehicles.xml.gz")
     assert config['transit']['transitScheduleFile'] == os.path.join(tmp_path, str(i), "output_transitSchedule.xml.gz")
     assert config['transit']['vehiclesFile'] == os.path.join(tmp_path, str(i), "output_transitVehicles.xml.gz")
     assert config['planCalcScore']['scoringParameters:default']['modeParams:car']["constant"] == "-1.0"

--- a/tests/test_autostep.py
+++ b/tests/test_autostep.py
@@ -185,7 +185,7 @@ def test_finding_and_setting_bad_param_leaves_config_unchanged(config):
 
 
 def test_autostep_config_first_iteration(tmp_path):
-    in_file = os.path.join("tests", "test_data", "test_config.xml")
+    in_file = os.path.join(os.path.dirname(__file__), "test_data", "test_config.xml")
     out_dir = os.path.join(tmp_path, "10")
     out_file = os.path.join(tmp_path, "0", "matsim_config.xml")
     autostep.autostep_config(
@@ -226,7 +226,7 @@ def test_autostep_config_first_iteration(tmp_path):
 
 
 def test_autostep_config(tmp_path):
-    in_file = os.path.join("tests", "test_data", "test_config.xml")
+    in_file = os.path.join(os.path.dirname(__file__), "test_data", "test_config.xml")
     out_dir = os.path.join(tmp_path, "20")
     out_file = os.path.join(tmp_path, "10", "matsim_config.xml")
     autostep.autostep_config(
@@ -281,7 +281,7 @@ def test_first_two_steps(tmp_path, fake_lambda_handler):
     event = {
         "orchestration": {
             "sim_root": str(tmp_path),
-            "seed_matsim_config_path": os.path.join("tests", "test_data", "test_config.xml"),
+            "seed_matsim_config_path": os.path.join(os.path.dirname(__file__), "test_data", "test_config.xml"),
             "start_index": "0",
             "total_iterations": "100",
             "step": "10",
@@ -364,7 +364,7 @@ def test_stepping(tmp_path, fake_lambda_handler):
 
     orchestration = {
         "sim_root": str(tmp_path),
-        "seed_matsim_config_path": os.path.join("tests", "test_data", "test_config.xml"),
+        "seed_matsim_config_path": os.path.join(os.path.dirname(__file__), "test_data", "test_config.xml"),
         "start_index": "0",
         "total_iterations": "30",
         "step": "10",
@@ -412,7 +412,7 @@ def test_stepping_with_cooling(tmp_path, fake_lambda_handler):
 
     orchestration = {
         "sim_root": str(tmp_path),
-        "seed_matsim_config_path": os.path.join("tests", "test_data", "test_config.xml"),
+        "seed_matsim_config_path": os.path.join(os.path.dirname(__file__), "test_data", "test_config.xml"),
         "start_index": "0",
         "total_iterations": "30",
         "step": "10",

--- a/tests/test_autostep.py
+++ b/tests/test_autostep.py
@@ -225,6 +225,46 @@ def test_autostep_config_first_iteration(tmp_path):
     assert config['strategy']['fractionOfIterationsToDisableInnovation'] == "0.8"
 
 
+def test_nonexistent_optional_input_module_ignored_when_fixing_relative_paths():
+    config_path = os.path.join(os.path.dirname(__file__), "test_data", "test_config_missing_all_vehicles.xml")
+    config = BaseConfig(config_path)
+    assert 'vehicles' not in config
+
+    autostep.fix_relative_input_paths_to_abs(
+        config,
+        config_path
+    )
+
+    assert 'vehicles' not in config
+
+
+def test_optional_vehicles_module_gets_relative_path_fixed():
+    config_path = os.path.join(os.path.dirname(__file__), "test_data", "test_config.xml")
+    config = BaseConfig(config_path)
+    assert not Path(config['vehicles']['vehiclesFile']).is_absolute()
+
+    autostep.fix_relative_input_paths_to_abs(
+        config,
+        config_path
+    )
+
+    assert Path(config['vehicles']['vehiclesFile']).is_absolute()
+
+
+def test_missing_nonoptional_module_throws_key_error_when_trying_to_fix_relative_paths():
+    config_path = os.path.join(os.path.dirname(__file__), "test_data", "test_config.xml")
+    config = BaseConfig(config_path)
+    del config['network']
+
+    with pytest.raises(KeyError) as error_info:
+        autostep.fix_relative_input_paths_to_abs(
+            config,
+            config_path
+        )
+
+    assert "'inputNetworkFile' not found in params/sets" in str(error_info.value)
+
+
 def test_autostep_config(tmp_path):
     in_file = os.path.join(os.path.dirname(__file__), "test_data", "test_config.xml")
     out_dir = os.path.join(tmp_path, "20")

--- a/tests/test_autostep.py
+++ b/tests/test_autostep.py
@@ -296,6 +296,55 @@ def test_autostep_config(tmp_path):
     assert config['strategy']['fractionOfIterationsToDisableInnovation'] == "0.8"
 
 
+def test_autostep_with_missing_optional_allvehicles_ignores_vehicles_module(tmp_path):
+    in_file = os.path.join(os.path.dirname(__file__), "test_data", "test_config_missing_all_vehicles.xml")
+    out_dir = os.path.join(tmp_path, "20")
+    out_file = os.path.join(tmp_path, "10", "matsim_config.xml")
+    autostep.autostep_config(
+        sim_root=tmp_path,
+        seed_matsim_config_path=in_file,
+        start_index="20",
+        total_iterations="100",
+        step="10",
+        biteration_matsim_config_path=out_file,
+        overrides=(
+           "modeParams:car/constant", "-1.0",
+           "scoringParameters:unknown/modeParams:bus/constant", "-1.0"
+        )
+    )
+    assert os.path.exists(out_file)
+    config = BaseConfig(out_file)
+    assert config['controler']['lastIteration'] == '20'
+    assert config['controler']['outputDirectory'] == out_dir
+    assert 'vehicles' not in config
+
+
+def test_autostep_with_missing_allvehicles_updates_other_module_paths(tmp_path):
+    in_file = os.path.join(os.path.dirname(__file__), "test_data", "test_config_missing_all_vehicles.xml")
+    out_dir = os.path.join(tmp_path, "20")
+    out_file = os.path.join(tmp_path, "10", "matsim_config.xml")
+    autostep.autostep_config(
+        sim_root=tmp_path,
+        seed_matsim_config_path=in_file,
+        start_index="20",
+        total_iterations="100",
+        step="10",
+        biteration_matsim_config_path=out_file,
+        overrides=(
+           "modeParams:car/constant", "-1.0",
+           "scoringParameters:unknown/modeParams:bus/constant", "-1.0"
+        )
+    )
+    assert os.path.exists(out_file)
+    config = BaseConfig(out_file)
+    assert config['controler']['lastIteration'] == '20'
+    assert config['controler']['outputDirectory'] == out_dir
+    assert config['network']['inputNetworkFile'] == os.path.join(tmp_path, "10", "output_network.xml.gz")
+    assert config['plans']['inputPlansFile'] == os.path.join(tmp_path, "10", "output_plans.xml.gz")
+    assert config['transit']['transitScheduleFile'] == os.path.join(tmp_path, "10", "output_transitSchedule.xml.gz")
+    assert config['transit']['vehiclesFile'] == os.path.join(tmp_path, "10", "output_transitVehicles.xml.gz")
+
+
 @pytest.fixture()
 def fake_lambda_handler():
     return lambda_handler

--- a/tests/test_data/mm_test.xml
+++ b/tests/test_data/mm_test.xml
@@ -14,6 +14,9 @@
     <param name="inputPersonAttributesFile" value="test_inputs/attributes.xml"/>
     <param name="subpopulationAttributeName" value="subpopulation"/>
   </module>
+  <module name="vehicles" >
+    <param name="vehiclesFile" value="test_inputs/all_vehicles.xml" />
+  </module>
   <module name="transit">
     <param name="useTransit" value="true"/>
     <param name="transitScheduleFile" value="test_inputs/transitschedule.xml"/>

--- a/tests/test_data/test_abspath_config.xml
+++ b/tests/test_data/test_abspath_config.xml
@@ -18,6 +18,10 @@
 	<param name="inputPlansFile" value="/test/population.xml.gz" />
 </module>
 <!-- ====================================================================== -->
+<module name="vehicles" >
+	<param name="vehiclesFile" value="/test/all_vehicles.xml" />
+</module>
+<!-- ====================================================================== -->
 <module name="transit" >
 	<param name="transitScheduleFile" value="/test/schedule-merged.xml" />
 	<param name="vehiclesFile" value="/test/vehicles.xml" />

--- a/tests/test_data/test_columbus_es_config.xml
+++ b/tests/test_data/test_columbus_es_config.xml
@@ -18,6 +18,10 @@
 		<param name="subpopulationAttributeName" value="subpopulation" />
 	</module>
 
+	<module name="vehicles" >
+		<param name="vehiclesFile" value="$matsim_source/output_vehicles.xml.gz" />
+	</module>
+
 	<module name="transit">
 		<param name="useTransit" value="true" />
 		<param name="transitScheduleFile" value="$matsim_source/output_transitSchedule.xml.gz" />

--- a/tests/test_data/test_config.json
+++ b/tests/test_data/test_config.json
@@ -29,6 +29,11 @@
         "subpopulationAttributeName": "subpopulation"
       }
     },
+    "vehicles": {
+      "params": {
+        "vehiclesFile": "~/test/all_vehicles.xml"
+      }
+    },
     "transit": {
       "params": {
         "inputScheduleCRS": "null",

--- a/tests/test_data/test_config.xml
+++ b/tests/test_data/test_config.xml
@@ -36,6 +36,10 @@
 	<param name="subpopulationAttributeName" value="subpopulation" />
 </module>
 <!-- ====================================================================== -->
+<module name="vehicles" >
+	<param name="vehiclesFile" value="~/test/all_vehicles.xml" />
+</module>
+<!-- ====================================================================== -->
 <module name="transit" >
 	<!-- The Coordinates Reference System in which the coordinates are expressed in the input file. At import, the coordinates will be converted to the coordinate system defined in "global", and willbe converted back at export. If not specified, no conversion happens. -->
 	<param name="inputScheduleCRS" value="null" />

--- a/tests/test_data/test_config_missing_all_vehicles.xml
+++ b/tests/test_data/test_config_missing_all_vehicles.xml
@@ -1,0 +1,540 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
+<config>
+<!-- ====================================================================== -->
+<module name="global" >
+	<param name="coordinateSystem" value="EPSG:27700" />
+	<param name="insistingOnDeprecatedConfigVersion" value="true" />
+	<!-- "global" number of threads.  This number is used, e.g., for replanning, but NOT in the mobsim.  This can typically be set to as many cores as you have available, or possibly even slightly more. -->
+	<param name="numberOfThreads" value="32" />
+	<param name="randomSeed" value="4711" />
+</module>
+<!-- ====================================================================== -->
+<module name="network" >
+	<!-- The Coordinates Reference System in which the coordinates are expressed in the input file. At import, the coordinates will be converted to the coordinate system defined in "global", and willbe converted back at export. If not specified, no conversion happens. -->
+	<param name="inputCRS" value="null" />
+	<param name="inputChangeEventsFile" value="null" />
+	<param name="inputNetworkFile" value="~/test/network.xml" />
+	<param name="laneDefinitionsFile" value="null" />
+	<param name="timeVariantNetwork" value="false" />
+</module>
+<!-- ====================================================================== -->
+<module name="plans" >
+	<param name="insistingOnUsingDeprecatedPersonAttributeFile" value="true" />
+	<!-- String: minOfDurationAndEndTime tryEndTimeThenDuration endTimeOnly. Anything besides minOfDurationAndEndTime will internally use a different (simpler) version of the TimeAllocationMutator. -->
+	<param name="activityDurationInterpretation" value="tryEndTimeThenDuration" />
+	<!-- The Coordinates Reference System in which the coordinates are expressed in the input file. At import, the coordinates will be converted to the coordinate system defined in "global", and willbe converted back at export. If not specified, no conversion happens. -->
+	<param name="inputCRS" value="null" />
+	<!-- Path to a file containing person attributes (required file format: ObjectAttributes). -->
+	<param name="inputPersonAttributesFile" value="~/test/population_attributes.xml.gz" />
+	<param name="inputPlansFile" value="~/test/population.xml.gz" />
+	<!-- Defines how routes are stored in memory. Currently supported: LinkNetworkRoute, CompressedNetworkRoute. -->
+	<param name="networkRouteType" value="LinkNetworkRoute" />
+	<!-- (not tested) will remove plan attributes that are presumably not used, such as activityStartTime. default=false -->
+	<param name="removingUnnecessaryPlanAttributes" value="false" />
+	<!-- Name of the (Object)Attribute defining the subpopulation to which pertains a Person (as freight, through traffic, etc.). The attribute must be of String type.  Change away from default only in desperate situations. -->
+	<param name="subpopulationAttributeName" value="subpopulation" />
+</module>
+<module name="transit" >
+	<!-- The Coordinates Reference System in which the coordinates are expressed in the input file. At import, the coordinates will be converted to the coordinate system defined in "global", and willbe converted back at export. If not specified, no conversion happens. -->
+	<param name="inputScheduleCRS" value="null" />
+	<!-- Optional input file containing additional attributes for transit lines, stored as ObjectAttributes. -->
+	<param name="transitLinesAttributesFile" value="null" />
+	<!-- Comma-separated list of transportation modes that are handled as transit. Defaults to 'pt'. -->
+	<param name="transitModes" value="bus,train" />
+	<!-- Input file containing the transit schedule to be simulated. -->
+	<param name="transitScheduleFile" value="~/test/schedule-merged.xml" />
+	<!-- Optional input file containing additional attributes for transit stop facilities, stored as ObjectAttributes. -->
+	<param name="transitStopsAttributesFile" value="null" />
+	<!-- Set this parameter to true if transit should be simulated, false if not. -->
+	<param name="useTransit" value="true" />
+	<!-- Input file containing the vehicles used by the departures in the transit schedule. -->
+	<param name="vehiclesFile" value="~/test/vehicles.xml" />
+</module>
+<!-- ====================================================================== -->
+<module name="swissRailRaptor">
+	<param name="useModeMappingForPassengers" value="true" />
+	<parameterset type="intermodalAccessEgress">
+		<param name="mode" value="walk" />
+		<param name="maxRadius" value="1000" />
+	  </parameterset>
+	<parameterset type="modeMapping">
+	  <param name="routeMode" value="bus" />
+	  <param name="passengerMode" value="bus" />
+	</parameterset>
+	<parameterset type="modeMapping">
+	  <param name="routeMode" value="train" />
+	  <param name="passengerMode" value="train" />
+	</parameterset>
+</module>
+<!-- ====================================================================== -->
+<module name="SBBPt" >
+	<param name="deterministicServiceModes" value="train" />
+	<param name="createLinkEventsInterval" value="1" />
+</module>
+<!-- ====================================================================== -->
+<module name="TimeAllocationMutator" >
+	<!-- Default:true; Defines whether time mutation changes an activity's duration. -->
+	<param name="mutationAffectsDuration" value="true" />
+	<!-- Default:1800.0; Defines how many seconds a time mutation can maximally shift a time. -->
+	<param name="mutationRange" value="1000.0" />
+	<!-- false; Use individual settings for each subpopulation. If enabled but no settings are found, regular settings are uses as fallback. -->
+	<param name="useIndividualSettingsForSubpopulations" value="false" />
+</module>
+<!-- ====================================================================== -->
+<module name="subtourModeChoice" >
+	<!-- Defines the chain-based modes, seperated by commas -->
+	<param name="chainBasedModes" value="car,bike" />
+	<!-- Defines whether car availability must be considered or not. A agent has no car only if it has no license, or never access to a car -->
+	<param name="considerCarAvailability" value="false" />
+	<!-- Defines all the modes available, including chain-based modes, seperated by commas -->
+	<param name="modes" value="car,bus,train,walk,bike" />
+</module>
+<!-- ====================================================================== -->
+<module name="parallelEventHandling" >
+	<!-- Estimated number of events during mobsim run. An optional optimization hint for the framework. -->
+	<param name="estimatedNumberOfEvents" value="null" />
+	<!-- Number of threads for parallel events handler. _null_ means the framework decides by itself. 0 is currently not possible. -->
+	<param name="numberOfThreads" value="32" />
+	<!-- If enabled, each event handler is assigned to its own thread. Note that enabling this feature disabled the numberOfThreads option! This feature is still experimental! -->
+	<param name="oneThreadPerHandler" value="false" />
+	<!-- If enabled, it is ensured that all events that are created during a time step of the mobility simulation are processed before the next time step is simulated. E.g. neccessary when within-day replanning is used. -->
+	<param name="synchronizeOnSimSteps" value="true" />
+</module>
+<!-- ====================================================================== -->
+<module name="controler" >
+	<!-- Sets whether graphs showing some analyses should automatically be generated during the simulation. The generation of graphs usually takes a small amount of time that does not have any weight in big simulations, but add a significant overhead in smaller runs or in test cases where the graphical output is not even requested. -->
+	<param name="createGraphs" value="true" />
+	<!-- true if at the end of a run, plans, network, config etc should be dumped to a file -->
+	<param name="dumpDataAtEnd" value="true" />
+	<!-- Default=false. If enabled, the router takes travel times needed for turning moves into account. Cannot be used if the (Fast)AStarLandmarks routing or TravelTimeCalculator.separateModes is enabled. -->
+	<param name="enableLinkToLinkRouting" value="false" />
+	<!-- Default=xml; Specifies the file format for writing events. Currently supported: xml.
+	Multiple values can be specified separated by commas (','). -->
+	<param name="eventsFileFormat" value="xml" />
+	<!-- Default=0;  -->
+	<param name="firstIteration" value="0" />
+	<!-- Default=1000;  -->
+	<param name="lastIteration" value="100" />
+	<!-- Defines which mobility simulation will be used. Currently supported: qsim JDEQSim 
+	Depending on the chosen mobsim, you'll have to add additional config modules to configure the corresponding mobsim.
+	For 'qsim', add a module 'qsim' to the config. -->
+	<param name="mobsim" value="qsim" />
+	<param name="outputDirectory" value="model_out" />
+	<!-- Possible values: failIfDirectoryExists, overwriteExistingFiles, deleteDirectoryIfExists -->
+	<param name="overwriteFiles" value="failIfDirectoryExists" />
+	<!-- The type of routing (least cost path) algorithm used, may have the values: Dijkstra, FastDijkstra, AStarLandmarks or FastAStarLandmarks -->
+	<param name="routingAlgorithmType" value="Dijkstra" />
+	<!-- An identifier for the current run which is used as prefix for output files and mentioned in output xml files etc. -->
+	<param name="runId" value="null" />
+	<!-- Comma-separated list of visualizer output file formats. `transims', `googleearth', and `otfvis'. -->
+	<param name="snapshotFormat" value="" />
+	<!-- iterationNumber % writeEventsInterval == 0 defines in which iterations events are written to a file. `0' disables events writing completely. -->
+	<param name="writeEventsInterval" value="1" />
+	<!-- iterationNumber % writePlansInterval == 0 defines (hopefully) in which iterations plans are written to a file. `0' disables plans writing completely.  Some plans in early iterations are always written -->
+	<param name="writePlansInterval" value="50" />
+	<!-- iterationNumber % writeSnapshotsInterval == 0 defines in which iterations snapshots are written to a file. `0' disables snapshots writing completely -->
+	<param name="writeSnapshotsInterval" value="1" />
+</module>
+<!-- ====================================================================== -->
+<module name="qsim" >
+	<!-- If set to true, creates a vehicle for each person corresponding to every network mode. However, this will be overridden if vehicle source is fromVehiclesData. -->
+	<param name="creatingVehiclesForAllNetworkModes" value="true" />
+	<param name="endTime" value="24:00:00" />
+	<param name="flowCapacityFactor" value="0.01" />
+	<!-- decides if waiting vehicles enter the network after or before the already driving vehicles were moved. Default: false -->
+	<param name="insertingWaitingVehiclesBeforeDrivingVehicles" value="false" />
+	<!-- If link dynamics is set as SeepageQ, set to false if all seep modes should perform seepage. Default is true (better option). -->
+	<param name="isRestrictingSeepage" value="true" />
+	<!-- If link dynamics is set as SeepageQ, set to true if seep mode do not consumes any space on the link. Default is false. -->
+	<param name="isSeepModeStorageFree" value="false" />
+	<!-- default: FIFO; options: FIFO PassingQ SeepageQ -->
+	<param name="linkDynamics" value="FIFO" />
+	<!-- The (initial) width of the links of the network. Use positive floating point values. This is used only for visualisation. -->
+	<param name="linkWidth" value="30.0" />
+	<!-- [comma-separated list] Defines which modes are congested modes. Technically, these are the modes that the departure handler of the netsimengine handles.  Effective cell size, effective lane width, flow capacity factor, and storage capacity factor need to be set with diligence.  Need to be vehicular modes to make sense. -->
+	<param name="mainMode" value="car" />
+	<!-- Shortens a link in the visualization, i.e. its start and end point are moved into towards the center. Does not affect traffic flow.  -->
+	<param name="nodeOffset" value="0.0" />
+	<!-- Number of threads used for the QSim.  Note that this setting is independent from the "global" threads setting.  In contrast to earlier versions, the non-parallel special version is no longer there. -->
+	<param name="numberOfThreads" value="32" />
+	<!-- Boolean. `true': stuck vehicles are removed, aborting the plan; `false': stuck vehicles are forced into the next link. `false' is probably the better choice. -->
+	<param name="removeStuckVehicles" value="false" />
+	<!-- If link dynamics is set as SeepageQ, set a seep mode. Default is bike. -->
+	<param name="seepMode" value="bike" />
+	<!-- Possible values: minOfEndtimeAndMobsimFinished, onlyUseEndtime -->
+	<param name="simEndtimeInterpretation" value="null" />
+	<!-- Options: maxOfStarttimeAndEarliestActivityEnd onlyUseStarttime  -->
+	<param name="simStarttimeInterpretation" value="maxOfStarttimeAndEarliestActivityEnd" />
+	<!-- snapshotStyle. One of: equiDist queue withHoles withHolesAndShowHoles kinematicWaves  -->
+	<param name="snapshotStyle" value="equiDist" />
+	<param name="snapshotperiod" value="00:00:00" />
+	<param name="startTime" value="00:00:00" />
+	<param name="storageCapacityFactor" value="0.01" />
+	<!-- time in seconds.  Time after which the frontmost vehicle on a link is called `stuck' if it does not move. -->
+	<param name="stuckTime" value="10.0" />
+	<param name="timeStepSize" value="00:00:01" />
+	<!-- options: queue withHoles kinematicWaves  -->
+	<param name="trafficDynamics" value="queue" />
+	<!-- Set this parameter to true if lanes should be used, false if not. -->
+	<param name="useLanes" value="false" />
+	<!-- If a route does not reference a vehicle, agents will use the vehicle with the same id as their own. -->
+	<param name="usePersonIdForMissingVehicleId" value="true" />
+	<!-- If false, the qsim accumulates fractional flows up to one flow unit in every time step.  If true, flows are updated only if an agent wants to enter the link or an agent is added to buffer. Default is true. -->
+	<param name="usingFastCapacityUpdate" value="true" />
+	<!-- if the qsim should use as many runners as there are threads (Christoph's dissertation version) or more of them, together with a thread pool (seems to be faster in some situations, but is not tested). -->
+	<param name="usingThreadpool" value="true" />
+	<!-- Defines what happens if an agent wants to depart, but the specified vehicle is not available. One of: teleport wait exception  -->
+	<param name="vehicleBehavior" value="teleport" />
+	<!-- If vehicles should all be the same default vehicle, or come from the vehicles file, or something else.  Possible values:  defaultVehicle modeVehicleTypesFromVehiclesData fromVehiclesData -->
+	<param name="vehiclesSource" value="defaultVehicle" />
+</module>
+<!-- ====================================================================== -->
+<module name="transitRouter" >
+	<!-- additional time the router allocates when a line switch happens. Can be interpreted as a 'safety' time that agents need to safely transfer from one line to another -->
+	<param name="additionalTransferTime" value="0.0" />
+	<!-- Factor with which direct walk generalized cost is multiplied before it is compared to the pt generalized cost.  Set to a very high value to reduce direct walk results. -->
+	<param name="directWalkFactor" value="1.0" />
+	<!-- step size to increase searchRadius if no stops are found -->
+	<param name="extensionRadius" value="100.0" />
+	<!-- maximum beeline distance between stops that agents could transfer to by walking -->
+	<param name="maxBeelineWalkConnectionDistance" value="100.0" />
+	<!-- the radius in which stop locations are searched, given a start or target coordinate -->
+	<param name="searchRadius" value="1000.0" />
+</module>
+<!-- ====================================================================== -->
+<module name="planCalcScore" >
+	<!-- logit model scale parameter. default: 1.  Has name and default value for historical reasons (see Bryan Raney's phd thesis). -->
+	<param name="BrainExpBeta" value="1.0" />
+	<param name="PathSizeLogitBeta" value="1.0" />
+	<!-- fraction of iterations at which MSA score averaging is started. The matsim theory department suggests to use this together with switching off choice set innovation (where a similar switch exists), but it has not been tested yet. -->
+	<param name="fractionOfIterationsToStartScoreMSA" value="null" />
+	<!-- new_score = (1-learningRate)*old_score + learningRate * score_from_mobsim.  learning rates close to zero emulate score averaging, but slow down initial convergence -->
+	<param name="learningRate" value="1.0" />
+	<!-- There used to be a plateau between duration=0 and duration=zeroUtilityDuration. This caused durations to evolve to zero once they were below zeroUtilityDuration, causing problems.  Only use this switch if you need to be backwards compatible with some old results.  (changed nov'13) -->
+	<param name="usingOldScoringBelowZeroUtilityDuration" value="false" />
+	<!-- write a plans file in each iteration directory which contains what each agent actually did, and the score it received. -->
+	<param name="writeExperiencedPlans" value="false" />
+	<parameterset type="scoringParameters" >
+		<param name="earlyDeparture" value="-0.0" />
+		<param name="lateArrival" value="-18.0" />
+		<param name="marginalUtilityOfMoney" value="0.0" />
+		<param name="performing" value="6.0" />
+		<param name="subpopulation" value="default" />
+		<param name="utilityOfLineSwitch" value="-1.0" />
+		<param name="waiting" value="-1.0" />
+		<param name="waitingPt" value="-1.0" />
+		<parameterset type="activityParams" >
+			<param name="activityType" value="education" />
+			<param name="closingTime" value="17:00:00" />
+			<param name="earliestEndTime" value="undefined" />
+			<param name="latestStartTime" value="undefined" />
+			<param name="minimalDuration" value="06:00:00" />
+			<param name="openingTime" value="08:30:00" />
+			<param name="priority" value="1.0" />
+			<param name="scoringThisActivityAtAll" value="true" />
+			<!-- typical duration of activity.  needs to be defined and non-zero.  in sec. -->
+			<param name="typicalDuration" value="06:00:00" />
+			<!-- method to compute score at typical duration.  Options: | uniform | relative | Use uniform for backwards compatibility (all activities same score; higher proba to drop long acts). -->
+			<param name="typicalDurationScoreComputation" value="relative" />
+		</parameterset>
+		<parameterset type="activityParams" >
+			<param name="activityType" value="home" />
+			<param name="closingTime" value="undefined" />
+			<param name="earliestEndTime" value="undefined" />
+			<param name="latestStartTime" value="undefined" />
+			<param name="minimalDuration" value="01:00:00" />
+			<param name="openingTime" value="undefined" />
+			<param name="priority" value="1.0" />
+			<param name="scoringThisActivityAtAll" value="true" />
+			<!-- typical duration of activity.  needs to be defined and non-zero.  in sec. -->
+			<param name="typicalDuration" value="12:00:00" />
+			<!-- method to compute score at typical duration.  Options: | uniform | relative | Use uniform for backwards compatibility (all activities same score; higher proba to drop long acts). -->
+			<param name="typicalDurationScoreComputation" value="relative" />
+		</parameterset>
+		<parameterset type="activityParams" >
+			<param name="activityType" value="work" />
+			<param name="closingTime" value="19:00:00" />
+			<param name="earliestEndTime" value="undefined" />
+			<param name="latestStartTime" value="undefined" />
+			<param name="minimalDuration" value="08:00:00" />
+			<param name="openingTime" value="08:00:00" />
+			<param name="priority" value="1.0" />
+			<param name="scoringThisActivityAtAll" value="true" />
+			<!-- typical duration of activity.  needs to be defined and non-zero.  in sec. -->
+			<param name="typicalDuration" value="09:00:00" />
+			<!-- method to compute score at typical duration.  Options: | uniform | relative | Use uniform for backwards compatibility (all activities same score; higher proba to drop long acts). -->
+			<param name="typicalDurationScoreComputation" value="relative" />
+		</parameterset>
+		<parameterset type="modeParams" >
+			<!-- [utils] alternative-specific constant.  no guarantee that this is used anywhere. default=0 to be backwards compatible for the time being -->
+			<param name="constant" value="0.0" />
+			<!-- [utils/m] utility of walking per m, normally negative.  this is on top of the time (dis)utility. -->
+			<param name="marginalUtilityOfDistance_util_m" value="0.0" />
+			<!-- [utils/hr] additional marginal utility of traveling.  normally negative.  this comes on top of the opportunity cost of time -->
+			<param name="marginalUtilityOfTraveling_util_hr" value="-6.0" />
+			<param name="mode" value="car" />
+			<!-- [unit_of_money/m] conversion of distance into money. Normally negative. -->
+			<param name="monetaryDistanceRate" value="-0.0" />
+		</parameterset>
+		<parameterset type="modeParams" >
+			<!-- [utils] alternative-specific constant.  no guarantee that this is used anywhere. default=0 to be backwards compatible for the time being -->
+			<param name="constant" value="0.0" />
+			<!-- [utils/m] utility of walking per m, normally negative.  this is on top of the time (dis)utility. -->
+			<param name="marginalUtilityOfDistance_util_m" value="0.0" />
+			<!-- [utils/hr] additional marginal utility of traveling.  normally negative.  this comes on top of the opportunity cost of time -->
+			<param name="marginalUtilityOfTraveling_util_hr" value="-6.0" />
+			<param name="mode" value="pt" />
+			<!-- [unit_of_money/m] conversion of distance into money. Normally negative. -->
+			<param name="monetaryDistanceRate" value="-0.0" />
+		</parameterset>
+		<parameterset type="modeParams" >
+			<!-- [utils] alternative-specific constant.  no guarantee that this is used anywhere. default=0 to be backwards compatible for the time being -->
+			<param name="constant" value="0.0" />
+			<!-- [utils/m] utility of walking per m, normally negative.  this is on top of the time (dis)utility. -->
+			<param name="marginalUtilityOfDistance_util_m" value="-0.0" />
+			<!-- [utils/hr] additional marginal utility of traveling.  normally negative.  this comes on top of the opportunity cost of time -->
+			<param name="marginalUtilityOfTraveling_util_hr" value="-12.0" />
+			<param name="mode" value="walk" />
+			<!-- [unit_of_money/m] conversion of distance into money. Normally negative. -->
+			<param name="monetaryDistanceRate" value="0.0" />
+		</parameterset>
+		<parameterset type="modeParams" >
+			<!-- [utils] alternative-specific constant.  no guarantee that this is used anywhere. default=0 to be backwards compatible for the time being -->
+			<param name="constant" value="0.0" />
+			<!-- [utils/m] utility of walking per m, normally negative.  this is on top of the time (dis)utility. -->
+			<param name="marginalUtilityOfDistance_util_m" value="-0.0" />
+			<!-- [utils/hr] additional marginal utility of traveling.  normally negative.  this comes on top of the opportunity cost of time -->
+			<param name="marginalUtilityOfTraveling_util_hr" value="-12.0" />
+			<param name="mode" value="access_walk" />
+			<!-- [unit_of_money/m] conversion of distance into money. Normally negative. -->
+			<param name="monetaryDistanceRate" value="0.0" />
+		</parameterset>
+		<parameterset type="modeParams" >
+			<!-- [utils] alternative-specific constant.  no guarantee that this is used anywhere. default=0 to be backwards compatible for the time being -->
+			<param name="constant" value="0.0" />
+			<!-- [utils/m] utility of walking per m, normally negative.  this is on top of the time (dis)utility. -->
+			<param name="marginalUtilityOfDistance_util_m" value="-0.0" />
+			<!-- [utils/hr] additional marginal utility of traveling.  normally negative.  this comes on top of the opportunity cost of time -->
+			<param name="marginalUtilityOfTraveling_util_hr" value="-12.0" />
+			<param name="mode" value="bike" />
+			<!-- [unit_of_money/m] conversion of distance into money. Normally negative. -->
+			<param name="monetaryDistanceRate" value="-0.0" />
+		</parameterset>
+		<parameterset type="modeParams" >
+			<!-- [utils] alternative-specific constant.  no guarantee that this is used anywhere. default=0 to be backwards compatible for the time being -->
+			<param name="constant" value="0.0" />
+			<!-- [utils/m] utility of walking per m, normally negative.  this is on top of the time (dis)utility. -->
+			<param name="marginalUtilityOfDistance_util_m" value="-0.0" />
+			<!-- [utils/hr] additional marginal utility of traveling.  normally negative.  this comes on top of the opportunity cost of time -->
+			<param name="marginalUtilityOfTraveling_util_hr" value="-12.0" />
+			<param name="mode" value="train" />
+			<!-- [unit_of_money/m] conversion of distance into money. Normally negative. -->
+			<param name="monetaryDistanceRate" value="-0.0" />
+		</parameterset>
+		<parameterset type="modeParams" >
+			<!-- [utils] alternative-specific constant.  no guarantee that this is used anywhere. default=0 to be backwards compatible for the time being -->
+			<param name="constant" value="0.0" />
+			<!-- [utils/m] utility of walking per m, normally negative.  this is on top of the time (dis)utility. -->
+			<param name="marginalUtilityOfDistance_util_m" value="-0.0" />
+			<!-- [utils/hr] additional marginal utility of traveling.  normally negative.  this comes on top of the opportunity cost of time -->
+			<param name="marginalUtilityOfTraveling_util_hr" value="-12.0" />
+			<param name="mode" value="bus" />
+			<!-- [unit_of_money/m] conversion of distance into money. Normally negative. -->
+			<param name="monetaryDistanceRate" value="-0.0" />
+		</parameterset>
+	</parameterset>
+	<parameterset type="scoringParameters" >
+		<param name="earlyDeparture" value="-0.0" />
+		<param name="lateArrival" value="-18.0" />
+		<param name="marginalUtilityOfMoney" value="0.0" />
+		<param name="performing" value="6.0" />
+		<param name="subpopulation" value="unknown" />
+		<param name="utilityOfLineSwitch" value="-1.0" />
+		<param name="waiting" value="-1.0" />
+		<param name="waitingPt" value="-1.0" />
+		<parameterset type="activityParams" >
+			<param name="activityType" value="education" />
+			<param name="closingTime" value="17:00:00" />
+			<param name="earliestEndTime" value="undefined" />
+			<param name="latestStartTime" value="undefined" />
+			<param name="minimalDuration" value="06:00:00" />
+			<param name="openingTime" value="08:30:00" />
+			<param name="priority" value="1.0" />
+			<param name="scoringThisActivityAtAll" value="true" />
+			<!-- typical duration of activity.  needs to be defined and non-zero.  in sec. -->
+			<param name="typicalDuration" value="06:00:00" />
+			<!-- method to compute score at typical duration.  Options: | uniform | relative | Use uniform for backwards compatibility (all activities same score; higher proba to drop long acts). -->
+			<param name="typicalDurationScoreComputation" value="relative" />
+		</parameterset>
+		<parameterset type="activityParams" >
+			<param name="activityType" value="home" />
+			<param name="closingTime" value="undefined" />
+			<param name="earliestEndTime" value="undefined" />
+			<param name="latestStartTime" value="undefined" />
+			<param name="minimalDuration" value="01:00:00" />
+			<param name="openingTime" value="undefined" />
+			<param name="priority" value="1.0" />
+			<param name="scoringThisActivityAtAll" value="true" />
+			<!-- typical duration of activity.  needs to be defined and non-zero.  in sec. -->
+			<param name="typicalDuration" value="12:00:00" />
+			<!-- method to compute score at typical duration.  Options: | uniform | relative | Use uniform for backwards compatibility (all activities same score; higher proba to drop long acts). -->
+			<param name="typicalDurationScoreComputation" value="relative" />
+		</parameterset>
+		<parameterset type="activityParams" >
+			<param name="activityType" value="work" />
+			<param name="closingTime" value="19:00:00" />
+			<param name="earliestEndTime" value="undefined" />
+			<param name="latestStartTime" value="undefined" />
+			<param name="minimalDuration" value="08:00:00" />
+			<param name="openingTime" value="08:00:00" />
+			<param name="priority" value="1.0" />
+			<param name="scoringThisActivityAtAll" value="true" />
+			<!-- typical duration of activity.  needs to be defined and non-zero.  in sec. -->
+			<param name="typicalDuration" value="09:00:00" />
+			<!-- method to compute score at typical duration.  Options: | uniform | relative | Use uniform for backwards compatibility (all activities same score; higher proba to drop long acts). -->
+			<param name="typicalDurationScoreComputation" value="relative" />
+		</parameterset>
+		<parameterset type="modeParams" >
+			<!-- [utils] alternative-specific constant.  no guarantee that this is used anywhere. default=0 to be backwards compatible for the time being -->
+			<param name="constant" value="0.0" />
+			<!-- [utils/m] utility of walking per m, normally negative.  this is on top of the time (dis)utility. -->
+			<param name="marginalUtilityOfDistance_util_m" value="0.0" />
+			<!-- [utils/hr] additional marginal utility of traveling.  normally negative.  this comes on top of the opportunity cost of time -->
+			<param name="marginalUtilityOfTraveling_util_hr" value="-6.0" />
+			<param name="mode" value="car" />
+			<!-- [unit_of_money/m] conversion of distance into money. Normally negative. -->
+			<param name="monetaryDistanceRate" value="-0.0" />
+		</parameterset>
+		<parameterset type="modeParams" >
+			<!-- [utils] alternative-specific constant.  no guarantee that this is used anywhere. default=0 to be backwards compatible for the time being -->
+			<param name="constant" value="0.0" />
+			<!-- [utils/m] utility of walking per m, normally negative.  this is on top of the time (dis)utility. -->
+			<param name="marginalUtilityOfDistance_util_m" value="0.0" />
+			<!-- [utils/hr] additional marginal utility of traveling.  normally negative.  this comes on top of the opportunity cost of time -->
+			<param name="marginalUtilityOfTraveling_util_hr" value="-6.0" />
+			<param name="mode" value="pt" />
+			<!-- [unit_of_money/m] conversion of distance into money. Normally negative. -->
+			<param name="monetaryDistanceRate" value="-0.0" />
+		</parameterset>
+		<parameterset type="modeParams" >
+			<!-- [utils] alternative-specific constant.  no guarantee that this is used anywhere. default=0 to be backwards compatible for the time being -->
+			<param name="constant" value="0.0" />
+			<!-- [utils/m] utility of walking per m, normally negative.  this is on top of the time (dis)utility. -->
+			<param name="marginalUtilityOfDistance_util_m" value="-0.0" />
+			<!-- [utils/hr] additional marginal utility of traveling.  normally negative.  this comes on top of the opportunity cost of time -->
+			<param name="marginalUtilityOfTraveling_util_hr" value="-12.0" />
+			<param name="mode" value="walk" />
+			<!-- [unit_of_money/m] conversion of distance into money. Normally negative. -->
+			<param name="monetaryDistanceRate" value="0.0" />
+		</parameterset>
+		<parameterset type="modeParams" >
+			<!-- [utils] alternative-specific constant.  no guarantee that this is used anywhere. default=0 to be backwards compatible for the time being -->
+			<param name="constant" value="0.0" />
+			<!-- [utils/m] utility of walking per m, normally negative.  this is on top of the time (dis)utility. -->
+			<param name="marginalUtilityOfDistance_util_m" value="-0.0" />
+			<!-- [utils/hr] additional marginal utility of traveling.  normally negative.  this comes on top of the opportunity cost of time -->
+			<param name="marginalUtilityOfTraveling_util_hr" value="-12.0" />
+			<param name="mode" value="access_walk" />
+			<!-- [unit_of_money/m] conversion of distance into money. Normally negative. -->
+			<param name="monetaryDistanceRate" value="0.0" />
+		</parameterset>
+		<parameterset type="modeParams" >
+			<!-- [utils] alternative-specific constant.  no guarantee that this is used anywhere. default=0 to be backwards compatible for the time being -->
+			<param name="constant" value="0.0" />
+			<!-- [utils/m] utility of walking per m, normally negative.  this is on top of the time (dis)utility. -->
+			<param name="marginalUtilityOfDistance_util_m" value="-0.0" />
+			<!-- [utils/hr] additional marginal utility of traveling.  normally negative.  this comes on top of the opportunity cost of time -->
+			<param name="marginalUtilityOfTraveling_util_hr" value="-12.0" />
+			<param name="mode" value="bike" />
+			<!-- [unit_of_money/m] conversion of distance into money. Normally negative. -->
+			<param name="monetaryDistanceRate" value="-0.0" />
+		</parameterset>
+		<parameterset type="modeParams" >
+			<!-- [utils] alternative-specific constant.  no guarantee that this is used anywhere. default=0 to be backwards compatible for the time being -->
+			<param name="constant" value="0.0" />
+			<!-- [utils/m] utility of walking per m, normally negative.  this is on top of the time (dis)utility. -->
+			<param name="marginalUtilityOfDistance_util_m" value="-0.0" />
+			<!-- [utils/hr] additional marginal utility of traveling.  normally negative.  this comes on top of the opportunity cost of time -->
+			<param name="marginalUtilityOfTraveling_util_hr" value="-12.0" />
+			<param name="mode" value="train" />
+			<!-- [unit_of_money/m] conversion of distance into money. Normally negative. -->
+			<param name="monetaryDistanceRate" value="-0.0" />
+		</parameterset>
+		<parameterset type="modeParams" >
+			<!-- [utils] alternative-specific constant.  no guarantee that this is used anywhere. default=0 to be backwards compatible for the time being -->
+			<param name="constant" value="0.0" />
+			<!-- [utils/m] utility of walking per m, normally negative.  this is on top of the time (dis)utility. -->
+			<param name="marginalUtilityOfDistance_util_m" value="-0.0" />
+			<!-- [utils/hr] additional marginal utility of traveling.  normally negative.  this comes on top of the opportunity cost of time -->
+			<param name="marginalUtilityOfTraveling_util_hr" value="-12.0" />
+			<param name="mode" value="bus" />
+			<!-- [unit_of_money/m] conversion of distance into money. Normally negative. -->
+			<param name="monetaryDistanceRate" value="-0.0" />
+		</parameterset>
+	</parameterset>
+</module>
+<!-- ====================================================================== -->
+<module name="strategy" >
+	<!-- the external executable will be called with a config file as argument.  This is the pathname to a possible skeleton config, to which additional information will be added.  Can be null. -->
+	<param name="ExternalExeConfigTemplate" value="null" />
+	<!-- time out value (in seconds) after which matsim will consider the external strategy as failed -->
+	<param name="ExternalExeTimeOut" value="3600" />
+	<!-- root directory for temporary files generated by the external executable. Provided as a service; I don't think this is used by MATSim. -->
+	<param name="ExternalExeTmpFileRootDir" value="null" />
+	<!-- fraction of iterations where innovative strategies are switched off.  Something link 0.8 should be good.  E.g. if you run from iteration 400 to iteration 500, innovation is switched off at iteration 480 -->
+	<param name="fractionOfIterationsToDisableInnovation" value="0.95" />
+	<!-- maximum number of plans per agent.  ``0'' means ``infinity''.  Currently (2010), ``5'' is a good number -->
+	<param name="maxAgentPlanMemorySize" value="5" />
+	<!-- strategyName of PlanSelector for plans removal.  Possible defaults: WorstPlanSelector SelectRandom SelectExpBetaForRemoval ChangeExpBetaForRemoval PathSizeLogitSelectorForRemoval . The current default, WorstPlanSelector is not a good choice from a discrete choice theoretical perspective. Alternatives, however, have not been systematically tested. kai, feb'12 -->
+	<param name="planSelectorForRemoval" value="WorstPlanSelector" />
+	<parameterset type="strategysettings" >
+		<!-- iteration after which strategy will be disabled.  most useful for ``innovative'' strategies (new routes, new times, ...). Normally, better use fractionOfIterationsToDisableInnovation -->
+		<param name="disableAfterIteration" value="-1" />
+		<!-- path to external executable (if applicable) -->
+		<param name="executionPath" value="null" />
+		<!-- strategyName of strategy.  Possible default names: SelectRandomBestScoreKeepLastSelectedChangeExpBetaSelectExpBetaSelectPathSizeLogit (selectors), ReRoute TimeAllocationMutator ChangeLegMode TimeAllocationMutator_ReRoute ChangeSingleLegMode ChangeSingleTripMode SubtourModeChoice ChangeTripMode TripSubtourModeChoice  (innovative strategies). -->
+		<param name="strategyName" value="ChangeSingleTripMode" />
+		<!-- subpopulation to which the strategy applies. "null" refers to the default population, that is, the set of persons for which no explicit subpopulation is defined (ie no subpopulation attribute) -->
+		<param name="subpopulation" value="unknown" />
+		<!-- weight of a strategy: for each agent, a strategy will be selected with a probability proportional to its weight -->
+		<param name="weight" value="0.1" />
+	</parameterset>
+	<parameterset type="strategysettings" >
+		<!-- iteration after which strategy will be disabled.  most useful for ``innovative'' strategies (new routes, new times, ...). Normally, better use fractionOfIterationsToDisableInnovation -->
+		<param name="disableAfterIteration" value="-1" />
+		<!-- path to external executable (if applicable) -->
+		<param name="executionPath" value="null" />
+		<!-- strategyName of strategy.  Possible default names: SelectRandomBestScoreKeepLastSelectedChangeExpBetaSelectExpBetaSelectPathSizeLogit (selectors), ReRoute TimeAllocationMutator ChangeLegMode TimeAllocationMutator_ReRoute ChangeSingleLegMode ChangeSingleTripMode SubtourModeChoice ChangeTripMode TripSubtourModeChoice  (innovative strategies). -->
+		<param name="strategyName" value="ReRoute" />
+		<!-- subpopulation to which the strategy applies. "null" refers to the default population, that is, the set of persons for which no explicit subpopulation is defined (ie no subpopulation attribute) -->
+		<param name="subpopulation" value="unknown" />
+		<!-- weight of a strategy: for each agent, a strategy will be selected with a probability proportional to its weight -->
+		<param name="weight" value="0.2" />
+	</parameterset>
+	<parameterset type="strategysettings" >
+		<!-- iteration after which strategy will be disabled.  most useful for ``innovative'' strategies (new routes, new times, ...). Normally, better use fractionOfIterationsToDisableInnovation -->
+		<param name="disableAfterIteration" value="-1" />
+		<!-- path to external executable (if applicable) -->
+		<param name="executionPath" value="null" />
+		<!-- strategyName of strategy.  Possible default names: SelectRandomBestScoreKeepLastSelectedChangeExpBetaSelectExpBetaSelectPathSizeLogit (selectors), ReRoute TimeAllocationMutator ChangeLegMode TimeAllocationMutator_ReRoute ChangeSingleLegMode ChangeSingleTripMode SubtourModeChoice ChangeTripMode TripSubtourModeChoice  (innovative strategies). -->
+		<param name="strategyName" value="TimeAllocationMutator_ReRoute" />
+		<!-- subpopulation to which the strategy applies. "null" refers to the default population, that is, the set of persons for which no explicit subpopulation is defined (ie no subpopulation attribute) -->
+		<param name="subpopulation" value="unknown" />
+		<!-- weight of a strategy: for each agent, a strategy will be selected with a probability proportional to its weight -->
+		<param name="weight" value="0.1" />
+	</parameterset>
+	<parameterset type="strategysettings" >
+		<!-- iteration after which strategy will be disabled.  most useful for ``innovative'' strategies (new routes, new times, ...). Normally, better use fractionOfIterationsToDisableInnovation -->
+		<param name="disableAfterIteration" value="-1" />
+		<!-- path to external executable (if applicable) -->
+		<param name="executionPath" value="null" />
+		<!-- strategyName of strategy.  Possible default names: SelectRandomBestScoreKeepLastSelectedChangeExpBetaSelectExpBetaSelectPathSizeLogit (selectors), ReRoute TimeAllocationMutator ChangeLegMode TimeAllocationMutator_ReRoute ChangeSingleLegMode ChangeSingleTripMode SubtourModeChoice ChangeTripMode TripSubtourModeChoice  (innovative strategies). -->
+		<param name="strategyName" value="SelectExpBeta" />
+		<!-- subpopulation to which the strategy applies. "null" refers to the default population, that is, the set of persons for which no explicit subpopulation is defined (ie no subpopulation attribute) -->
+		<param name="subpopulation" value="unknown" />
+		<!-- weight of a strategy: for each agent, a strategy will be selected with a probability proportional to its weight -->
+		<param name="weight" value="0.6" />
+	</parameterset>
+</module>
+</config>

--- a/tests/test_data/test_config_v12.xml
+++ b/tests/test_data/test_config_v12.xml
@@ -34,6 +34,10 @@
 	<param name="subpopulationAttributeName" value="subpopulation" />
 </module>
 <!-- ====================================================================== -->
+<module name="vehicles" >
+	<param name="vehiclesFile" value="~/test/all_vehicles.xml" />
+</module>
+<!-- ====================================================================== -->
 <module name="transit" >
 	<!-- The Coordinates Reference System in which the coordinates are expressed in the input file. At import, the coordinates will be converted to the coordinate system defined in "global", and willbe converted back at export. If not specified, no conversion happens. -->
 	<param name="inputScheduleCRS" value="null" />

--- a/tests/test_data/test_config_v14.xml
+++ b/tests/test_data/test_config_v14.xml
@@ -13,6 +13,11 @@
     <param name="inputPlansFile" value="/efs/population/population_xml/v5_20220429_TE/plans.xml.pz" />
   </module>
 
+
+  <module name="vehicles" >
+      <param name="vehiclesFile" value="~/test/all_vehicles.xml" />
+  </module>
+
   <module name="transit">
     <param name="useTransit" value="true" />
     <param name="transitScheduleFile" value="/efs/networks/network_0.75_freespeed/schedule.xml.gz" />

--- a/tests/test_data/test_path_config.xml
+++ b/tests/test_data/test_path_config.xml
@@ -17,6 +17,11 @@
 	<param name="inputPlansFile" value="../test/population.xml.gz" />
 </module>
 <!-- ====================================================================== -->
+<!-- ====================================================================== -->
+<module name="vehicles" >
+	<param name="vehiclesFile" value="../test/all_vehicles.xml" />
+</module>
+<!-- ====================================================================== -->
 <module name="transit" >
 	<param name="transitScheduleFile" value="~/test/schedule-merged.xml" />
 	<param name="vehiclesFile" value="/test/vehicles.xml" />

--- a/tests/test_data/test_temp_config.json
+++ b/tests/test_data/test_temp_config.json
@@ -29,6 +29,11 @@
         "subpopulationAttributeName": "subpopulation"
       }
     },
+    "vehicles": {
+      "params": {
+        "vehiclesFile": "~/test/all_vehicles.xml"
+      }
+    },
     "transit": {
       "params": {
         "inputScheduleCRS": "null",

--- a/tests/test_data/test_temp_config.xml
+++ b/tests/test_data/test_temp_config.xml
@@ -24,6 +24,9 @@
     <param name="removingUnnecessaryPlanAttributes" value="false"/>
     <param name="subpopulationAttributeName" value="subpopulation"/>
   </module>
+  <module name="vehicles">
+    <param name="vehiclesFile" value="~/test/all_vehicles.xml"/>
+  </module>
   <module name="transit">
     <param name="inputScheduleCRS" value="null"/>
     <param name="transitLinesAttributesFile" value="null"/>

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -9,7 +9,7 @@ from mc import step
 
 @pytest.fixture()
 def config():
-    in_file = Path("tests/test_data/test_config.xml")
+    in_file = Path(os.path.join(os.path.dirname(__file__), 'test_data', 'test_config.xml'))
     return BaseConfig(in_file)
 
 
@@ -71,7 +71,7 @@ def test_construct_overrides_map_from_tuple():
 
 
 def test_step_config(tmp_path):
-    in_file = "tests/test_data/test_config.xml"
+    in_file = os.path.join(os.path.dirname(__file__), 'test_data', 'test_config.xml')
     out_file = os.path.join(tmp_path, "test_config.xml")
     step.step_config(
         input_file=in_file,


### PR DESCRIPTION
Following @fredshone's advice here: https://github.com/arup-group/BitSim/pull/130#issuecomment-1287056487 I added support for all vehicles file which will allow its' use with bitsim (https://github.com/arup-group/BitSim/pull/130#issuecomment-1286919046)

Context: through the vehicles file we can set speeds for different mode vehicles, e.g. bike and walk (agents walking on the network also need a 'walk vehicle') (we still use the transit vehicles file or PT as usual)

The main complication with this was that we don't use the `all_vehicles.xml` file right now and would like that to still be possible. For that I needed to add an optional tag to some methods, as you will see below.

Got a couple of bitsim tests here:
- [one not using the `all_vehicles.xml` file, also knows as the good old times](https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/v2/executions/details/arn:aws:states:eu-west-1:758645626094:execution:kasia-mc-all-vehicles-test:no_all_vehicles_file_in_config_test_2)
- [one using the `all_vehicles.xml` file and output vehicles in subsequent biterations](https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/v2/executions/details/arn:aws:states:eu-west-1:758645626094:execution:kasia-mc-all-vehicles-test:use_all_vehicles_file_in_config_test_2)